### PR TITLE
Fixed: Multiple Strings in a Single DNS Record concatenate error

### DIFF
--- a/checkdmarc.py
+++ b/checkdmarc.py
@@ -497,9 +497,18 @@ def _query_dns(domain, record_type, nameservers=None, timeout=2.0):
     resolver.nameservers = nameservers
     resolver.timeout = timeout
     resolver.lifetime = timeout
-    return list(map(
-        lambda r: r.to_text().replace('"', '').rstrip("."),
-        resolver.query(domain, record_type, tcp=True)))
+    if record_type == "TXT":
+        resourcerecords = list(map(
+            lambda r: r.strings,
+            resolver.query(domain, record_type, tcp=True)))
+        _resourcerecord = [
+            resourcerecord[0][:0].join(resourcerecord) 
+            for resourcerecord in resourcerecords if resourcerecord]
+        return [r.decode('ascii') for r in _resourcerecord]
+    else:
+        return list(map(
+            lambda r: r.to_text().replace('"', '').rstrip("."),
+            resolver.query(domain, record_type, tcp=True)))
 
 
 def _get_mx_hosts(domain, nameservers=None, timeout=2.0):

--- a/checkdmarc.py
+++ b/checkdmarc.py
@@ -502,7 +502,7 @@ def _query_dns(domain, record_type, nameservers=None, timeout=2.0):
             lambda r: r.strings,
             resolver.query(domain, record_type, tcp=True)))
         _resourcerecord = [
-            resourcerecord[0][:0].join(resourcerecord) 
+            resourcerecord[0][:0].join(resourcerecord)
             for resourcerecord in resourcerecords if resourcerecord]
         return [r.decode('ascii') for r in _resourcerecord]
     else:


### PR DESCRIPTION
## Error
```
❯ dig smp.ne.jp txt +short
"v=spf1 +ip4:59.106.42.224/28 +ip4:210.188.229.224/27 +ip4:61.211.238.0/27 +ip4:61.211.237.192/26 +ip4:59.106.30.0/26 +ip4:59.10" "6.116.96/27 +ip4:59.106.117.0/26 +ip4:210.188.245.160/27 +ip4:210.188.233.32/27 +ip4:59.106.37.128/26 +ip4:59.106.106.192/26 +i" "p4:59.106.4.64/26 +ip4:59.106.100.128/25 +ip4:59.106.149.0/26 +ip4:59.106.193.160/27 +ip4:59.106.147.128/27 +ip4:59.106.4.0/26 " "include:spf01.smp.ne.jp ~all"
```
```
❯ checkdmarc smp.ne.jp | jq '.spf'
{
  "record": "v=spf1 +ip4:59.106.42.224/28 +ip4:210.188.229.224/27 +ip4:61.211.238.0/27 +ip4:61.211.237.192/26 +ip4:59.106.30.0/26 +ip4:59.10 6.116.96/27 +ip4:59.106.117.0/26 +ip4:210.188.245.160/27 +ip4:210.188.233.32/27 +ip4:59.106.37.128/26 +ip4:59.106.106.192/26 +i p4:59.106.4.64/26 +ip4:59.106.100.128/25 +ip4:59.106.149.0/26 +ip4:59.106.193.160/27 +ip4:59.106.147.128/27 +ip4:59.106.4.0/26  include:spf01.smp.ne.jp ~all",
  "valid": false,
  "warnings": [],
  "error": "smp.ne.jp: Expected mechanism at position 128 in: v=spf1 +ip4:59.106.42.224/28 +ip4:210.188.229.224/27 +ip4:61.211.238.0/27 +ip4:61.211.237.192/26 +ip4:59.106.30.0/26 +ip4:59.10 6.116.96/27 +ip4:59.106.117.0/26 +ip4:210.188.245.160/27 +ip4:210.188.233.32/27 +ip4:59.106.37.128/26 +ip4:59.106.106.192/26 +i p4:59.106.4.64/26 +ip4:59.106.100.128/25 +ip4:59.106.149.0/26 +ip4:59.106.193.160/27 +ip4:59.106.147.128/27 +ip4:59.106.4.0/26  include:spf01.smp.ne.jp ~all"
}
```

## Seealso
https://github.com/sdgathman/pyspf/blob/78d62421b2e7d6d9267969a2702766d6483ec7c6/spf.py#L1131