### PR TITLE
Minor fixes to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,22 @@
 Changelog
 =========
 
+2.8.1
+-----
+
+- Bugfix: CSV format `-f csv` for starttls header
+- Use python3 in docs Makefile for Sphinx build
+- Correct spelling of domains
+
 2.8.0
 -----
 
-- Bugix: Always raise warning when SPF type DNS records are found
+- Bugfix: Always raise warning when SPF type DNS records are found
 - Add check for proper SPF records for MX hosts
 - Add check for STARTTLS
 - Add option `-p/--parked` to check for best practices for parked domains
 - Add option `--mx` to provide a list of approved MX hostnames
 - Add `query_bimi_record()` to the API
-
 
 2.7.3
 -----
@@ -41,7 +47,7 @@ Changelog
 2.6.2
 -----
 
-- Properly concatenate multi-line TXT records 
+- Properly concatenate multi-line TXT records
 
 2.6.1
 -----

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ A Python module and command line utility for validating SPF and DMARC DNS record
 
     optional arguments:
       -h, --help            show this help message and exit
-      -p, --parked          Indicate that the doomains are parked
+      -p, --parked          Indicate that the domains are parked
       -d, --descriptions    include descriptions of DMARC tags in the JSON output
       -f FORMAT, --format FORMAT
                             specify JSON or CSV output format

--- a/checkdmarc.py
+++ b/checkdmarc.py
@@ -42,7 +42,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-__version__ = "2.8.0"
+__version__ = "2.8.1"
 
 DMARC_VERSION_REGEX_STRING = r"v=DMARC1;"
 BIMI_VERSION_REGEX_STRING = r"v=BIMI1;"
@@ -1377,8 +1377,8 @@ def query_spf_record(domain, nameservers=None, timeout=2.0):
     if len(spf_type_records) > 0:
         message = "SPF type DNS records found. Use of DNS Type SPF has been " \
                   "removed in the standards " \
-                   "track version of SPF, RFC 7208. These records should " \
-                   "be removed and replaced with TXT records: " \
+                  "track version of SPF, RFC 7208. These records should " \
+                  "be removed and replaced with TXT records: " \
                   "{0}".format(",".join(spf_type_records))
         warnings.append(message)
     warnings_str = ""
@@ -1403,8 +1403,8 @@ def query_spf_record(domain, nameservers=None, timeout=2.0):
                     domain, warnings_str))
     except dns.resolver.NoAnswer:
         raise SPFRecordNotFound(
-             "{0} does not have a SPF TXT record{1}".format(
-                    domain, warnings_str))
+            "{0} does not have a SPF TXT record{1}".format(
+                domain, warnings_str))
     except dns.resolver.NXDOMAIN:
         raise SPFRecordNotFound("The domain {0} does not exist".format(domain))
     except dns.exception.DNSException as error:
@@ -1843,7 +1843,7 @@ def check_domains(domains, parked=False, approved_mx_hostnames=None,
                   "dmarc_adkim", "dmarc_aspf",
                   "dmarc_fo", "dmarc_p", "dmarc_pct", "dmarc_rf", "dmarc_ri",
                   "dmarc_rua", "dmarc_ruf", "dmarc_sp",
-                  "mx", "startssl" "spf_record", "dmarc_record",
+                  "mx", "starttls", "spf_record", "dmarc_record",
                   "dmarc_record_location",
                   "mx_warnings", "spf_error",
                   "spf_warnings", "dmarc_error", "dmarc_warnings"]
@@ -2006,7 +2006,7 @@ def _main():
                             help="one or ore domains, or a single path to a "
                                  "file containing a list of domains")
     arg_parser.add_argument("-p", "--parked", help="Indicate that the "
-                                                   "doomains are parked",
+                                                   "domains are parked",
                             action="store_true", default=False)
     arg_parser.add_argument("-d", "--descriptions", action="store_true",
                             help="include descriptions of DMARC tags in "

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python -msphinx
+SPHINXBUILD   = python3 -msphinx
 SPHINXPROJ    = checkdmarc
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup
 from codecs import open
 from os import path
 
-__version__ = "2.8.0"
+__version__ = "2.8.1"
 
 desc = "A Python module and command line parser for SPF and DMARC records"
 


### PR DESCRIPTION
I fixed a bug in 2.8.0 regarding -f csv format output, and made a few minor changes. Diff is smaller if you exclude whitespace (-w).

Bugfix: CSV format `-f csv` for starttls header.
Use python3 in docs Makefile for Sphinx build.
Correct spelling of domains. Fix minor whitespace, PEP8 warnings.

