### PR TITLE
Add Support for User Defined DNS Resolver Object

### DIFF
--- a/checkdmarc.py
+++ b/checkdmarc.py
@@ -616,8 +616,8 @@ def get_base_domain(domain, use_fresh_psl=False):
         return publicsuffix2.get_sld(domain)
 
 
-def _query_dns(domain, record_type, nameservers=None, resolver=None, timeout=2.0,
-               cache=None):
+def _query_dns(domain, record_type, nameservers=None, resolver=None,
+               timeout=2.0, cache=None):
     """
     Queries DNS
 
@@ -625,7 +625,8 @@ def _query_dns(domain, record_type, nameservers=None, resolver=None, timeout=2.0
         domain (str): The domain or subdomain to query about
         record_type (str): The record type to query for
         nameservers (list): A list of one or more nameservers to use
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): Sets the DNS timeout in seconds
         cache (ExpiringDict): Cache storage
 
@@ -673,7 +674,8 @@ def _get_nameservers(domain, nameservers=None, resolver=None, timeout=2.0):
     Args:
         domain (str): A domain name
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an answer from DNS
 
     Returns:
@@ -687,8 +689,8 @@ def _get_nameservers(domain, nameservers=None, resolver=None, timeout=2.0):
     answers = []
     try:
 
-        answers = _query_dns(domain, "NS", nameservers=nameservers, resolver=resolver,
-                             timeout=timeout)
+        answers = _query_dns(domain, "NS", nameservers=nameservers,
+                             resolver=resolver, timeout=timeout)
     except dns.resolver.NXDOMAIN:
         raise DNSException("The domain {0} does not exist".format(domain))
     except dns.resolver.NoAnswer:
@@ -705,7 +707,8 @@ def _get_mx_hosts(domain, nameservers=None, resolver=None, timeout=2.0):
     Args:
         domain (str): A domain name
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an answer from DNS
 
     Returns:
@@ -719,8 +722,8 @@ def _get_mx_hosts(domain, nameservers=None, resolver=None, timeout=2.0):
     hosts = []
     try:
         logging.debug("Checking for MX records on {0}".format(domain))
-        answers = _query_dns(domain, "MX", nameservers=nameservers, resolver=resolver,
-                             timeout=timeout)
+        answers = _query_dns(domain, "MX", nameservers=nameservers,
+                             resolver=resolver, timeout=timeout)
         for record in answers:
             record = record.split(" ")
             preference = int(record[0])
@@ -744,7 +747,8 @@ def _get_a_records(domain, nameservers=None, resolver=None, timeout=2.0):
     Args:
         domain (str): A domain name
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an answer from DNS
 
     Returns:
@@ -758,8 +762,8 @@ def _get_a_records(domain, nameservers=None, resolver=None, timeout=2.0):
     addresses = []
     for qt in qtypes:
         try:
-            addresses += _query_dns(domain, qt, nameservers=nameservers, resolver=resolver,
-                                    timeout=timeout)
+            addresses += _query_dns(domain, qt, nameservers=nameservers,
+                                    resolver=resolver, timeout=timeout)
         except dns.resolver.NXDOMAIN:
             raise DNSException("The domain {0} does not exist".format(domain))
         except dns.resolver.NoAnswer:
@@ -782,7 +786,8 @@ def _get_reverse_dns(ip_address, nameservers=None, resolver=None, timeout=2.0):
     Returns:
         list: A list of reverse DNS hostnames
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an answer from DNS
 
     Raises:
@@ -791,8 +796,8 @@ def _get_reverse_dns(ip_address, nameservers=None, resolver=None, timeout=2.0):
     """
     try:
         name = dns.reversename.from_address(ip_address)
-        hostnames = _query_dns(name, "PTR", nameservers=nameservers, resolver=resolver,
-                               timeout=timeout)
+        hostnames = _query_dns(name, "PTR", nameservers=nameservers,
+                               resolver=resolver, timeout=timeout)
     except dns.resolver.NXDOMAIN:
         return []
     except Exception as error:
@@ -808,7 +813,8 @@ def _get_txt_records(domain, nameservers=None, resolver=None, timeout=2.0):
     Args:
         domain (str): A domain name
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an answer from DNS
 
     Returns:
@@ -819,8 +825,8 @@ def _get_txt_records(domain, nameservers=None, resolver=None, timeout=2.0):
 
     """
     try:
-        records = _query_dns(domain, "TXT", nameservers=nameservers, resolver=resolver,
-                             timeout=timeout)
+        records = _query_dns(domain, "TXT", nameservers=nameservers,
+                             resolver=resolver, timeout=timeout)
     except dns.resolver.NXDOMAIN:
         raise DNSException("The domain {0} does not exist".format(domain))
     except dns.resolver.NoAnswer:
@@ -839,7 +845,8 @@ def _query_dmarc_record(domain, nameservers=None, resolver=None, timeout=2.0):
     Args:
         domain (str): A domain name
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an record from DNS
 
     Returns:
@@ -851,8 +858,8 @@ def _query_dmarc_record(domain, nameservers=None, resolver=None, timeout=2.0):
     unrelated_records = []
 
     try:
-        records = _query_dns(target, "TXT", nameservers=nameservers, resolver=resolver,
-                             timeout=timeout)
+        records = _query_dns(target, "TXT", nameservers=nameservers,
+                             resolver=resolver, timeout=timeout)
         for record in records:
             if record.startswith("v=DMARC1"):
                 dmarc_record_count += 1
@@ -906,7 +913,8 @@ def _query_bmi_record(domain, selector="default", nameservers=None, resolver=Non
         domain (str): A domain name
         selector: the BIMI selector
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an record from DNS
 
     Returns:
@@ -918,8 +926,8 @@ def _query_bmi_record(domain, selector="default", nameservers=None, resolver=Non
     unrelated_records = []
 
     try:
-        records = _query_dns(target, "TXT", nameservers=nameservers, resolver=resolver,
-                             timeout=timeout)
+        records = _query_dns(target, "TXT", nameservers=nameservers,
+                             resolver=resolver, timeout=timeout)
         for record in records:
             if record.startswith("v=BIMI1"):
                 bmi_record_count += 1
@@ -970,7 +978,8 @@ def query_dmarc_record(domain, nameservers=None, resolver=None, timeout=2.0):
     Args:
         domain (str): A domain name
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an record from DNS
 
     Returns:
@@ -990,8 +999,8 @@ def query_dmarc_record(domain, nameservers=None, resolver=None, timeout=2.0):
     warnings = []
     base_domain = get_base_domain(domain)
     location = domain.lower()
-    record = _query_dmarc_record(domain, nameservers=nameservers, resolver=resolver,
-                                 timeout=timeout)
+    record = _query_dmarc_record(domain, nameservers=nameservers,
+                                 resolver=resolver, timeout=timeout)
     try:
         root_records = _query_dns(domain.lower(), "TXT",
                                   nameservers=nameservers, resolver=resolver,
@@ -1004,8 +1013,8 @@ def query_dmarc_record(domain, nameservers=None, resolver=None, timeout=2.0):
         pass
 
     if record is None and domain != base_domain:
-        record = _query_dmarc_record(base_domain, nameservers=nameservers, resolver=resolver,
-                                     timeout=timeout)
+        record = _query_dmarc_record(base_domain, nameservers=nameservers,
+                                     resolver=resolver, timeout=timeout)
         location = base_domain
     if record is None:
         raise DMARCRecordNotFound(
@@ -1015,8 +1024,8 @@ def query_dmarc_record(domain, nameservers=None, resolver=None, timeout=2.0):
                         ("warnings", warnings)])
 
 
-def query_bimi_record(domain, selector="default", nameservers=None, resolver=None,
-                      timeout=2.0):
+def query_bimi_record(domain, selector="default", nameservers=None,
+                      resolver=None, timeout=2.0):
     """
     Queries DNS for a BIMI record
 
@@ -1024,7 +1033,8 @@ def query_bimi_record(domain, selector="default", nameservers=None, resolver=Non
         domain (str): A domain name
         selector (str): The BMI selector
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an record from DNS
 
     Returns:
@@ -1044,7 +1054,8 @@ def query_bimi_record(domain, selector="default", nameservers=None, resolver=Non
     base_domain = get_base_domain(domain)
     location = domain.lower()
     record = _query_bmi_record(domain, selector=selector,
-                               nameservers=nameservers, resolver=resolver, timeout=timeout)
+                               nameservers=nameservers, resolver=resolver,
+                               timeout=timeout)
     try:
         root_records = _query_dns(domain.lower(), "TXT",
                                   nameservers=nameservers, resolver=resolver,
@@ -1156,7 +1167,8 @@ def check_wildcard_dmarc_report_authorization(domain,
     Args:
         domain (str): The domain to check
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an answer from DNS
 
     Returns:
@@ -1194,7 +1206,8 @@ def check_wildcard_dmarc_report_authorization(domain,
 
 
 def verify_dmarc_report_destination(source_domain, destination_domain,
-                                    nameservers=None, resolver=None, timeout=2.0):
+                                    nameservers=None, resolver=None,
+                                    timeout=2.0):
     """
       Checks if the report destination accepts reports for the source domain
       per RFC 7489, section 7.1
@@ -1203,7 +1216,8 @@ def verify_dmarc_report_destination(source_domain, destination_domain,
           source_domain (str): The source domain
           destination_domain (str): The destination domain
           nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
           timeout (float): number of seconds to wait for an answer from DNS
 
       Returns:
@@ -1220,7 +1234,8 @@ def verify_dmarc_report_destination(source_domain, destination_domain,
 
     if get_base_domain(source_domain) != get_base_domain(destination_domain):
         if check_wildcard_dmarc_report_authorization(destination_domain,
-                                                     nameservers=nameservers, resolver=resolver):
+                                                     nameservers=nameservers,
+                                                     resolver=resolver):
             return True
         target = "{0}._report._dmarc.{1}".format(source_domain,
                                                  destination_domain)
@@ -1271,7 +1286,8 @@ def parse_dmarc_record(record, domain, parked=False,
         parked (bool): Indicates if a domain is parked
         include_tag_descriptions (bool): Include descriptions in parsed results
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an answer from DNS
 
     Returns:
@@ -1392,11 +1408,12 @@ def parse_dmarc_record(record, domain, parked=False,
                 email_domain = email_address.split("@")[-1]
                 if email_domain.lower() != domain.lower():
                     verify_dmarc_report_destination(domain, email_domain,
-                                                    nameservers=nameservers, resolver=resolver,
+                                                    nameservers=nameservers,
+                                                    resolver=resolver,
                                                     timeout=timeout)
                 try:
-                    _get_mx_hosts(email_domain, nameservers=nameservers, resolver=resolver,
-                                  timeout=timeout)
+                    _get_mx_hosts(email_domain, nameservers=nameservers,
+                                  resolver=resolver, timeout=timeout)
                 except _DMARCWarning:
                     raise DMARCReportEmailAddressMissingMXRecords(
                         "The domain for rua email address "
@@ -1432,11 +1449,12 @@ def parse_dmarc_record(record, domain, parked=False,
                 email_domain = email_address.split("@")[-1]
                 if email_domain.lower() != domain.lower():
                     verify_dmarc_report_destination(domain, email_domain,
-                                                    nameservers=nameservers, resolver=resolver,
+                                                    nameservers=nameservers,
+                                                    resolver=resolver,
                                                     timeout=timeout)
                 try:
-                    _get_mx_hosts(email_domain, nameservers=nameservers, resolver=resolver,
-                                  timeout=timeout)
+                    _get_mx_hosts(email_domain, nameservers=nameservers,
+                                  resolver=resolver, timeout=timeout)
                 except _SPFWarning:
                     raise DMARCReportEmailAddressMissingMXRecords(
                         "The domain for ruf email address "
@@ -1488,8 +1506,8 @@ def parse_dmarc_record(record, domain, parked=False,
     return OrderedDict([("tags", tags), ("warnings", warnings)])
 
 
-def get_dmarc_record(domain, include_tag_descriptions=False, nameservers=None, resolver=None,
-                     timeout=2.0):
+def get_dmarc_record(domain, include_tag_descriptions=False, nameservers=None,
+                     resolver=None, timeout=2.0):
     """
     Retrieves a DMARC record for a domain and parses it
 
@@ -1497,7 +1515,8 @@ def get_dmarc_record(domain, include_tag_descriptions=False, nameservers=None, r
         domain (str): A domain name
         include_tag_descriptions (bool): Include descriptions in parsed results
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an answer from DNS
 
     Returns:
@@ -1520,14 +1539,15 @@ def get_dmarc_record(domain, include_tag_descriptions=False, nameservers=None, r
         :exc:`checkdmarc.UnrelatedTXTRecordFound`
         :exc:`checkdmarc.DMARCReportEmailAddressMissingMXRecords`
     """
-    query = query_dmarc_record(domain, nameservers=nameservers, resolver=resolver,
-                               timeout=timeout)
+    query = query_dmarc_record(domain, nameservers=nameservers,
+                               resolver=resolver, timeout=timeout)
 
     tag_descriptions = include_tag_descriptions
 
     tags = parse_dmarc_record(query["record"], query["location"],
                               include_tag_descriptions=tag_descriptions,
-                              nameservers=nameservers, resolver=resolver, timeout=timeout)
+                              nameservers=nameservers, resolver=resolver,
+                              timeout=timeout)
 
     return OrderedDict([("record",
                          query["record"]),
@@ -1542,7 +1562,8 @@ def query_spf_record(domain, nameservers=None, resolver=None, timeout=2.0):
     Args:
         domain (str): A domain name
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an answer from DNS
 
     Returns:
@@ -1558,8 +1579,8 @@ def query_spf_record(domain, nameservers=None, resolver=None, timeout=2.0):
     spf_type_records = []
     spf_txt_records = []
     try:
-        spf_type_records += _query_dns(domain, "SPF", nameservers=nameservers, resolver=resolver,
-                                       timeout=timeout)
+        spf_type_records += _query_dns(domain, "SPF", nameservers=nameservers,
+                                       resolver=resolver, timeout=timeout)
     except (dns.resolver.NoAnswer, Exception):
         pass
 
@@ -1574,8 +1595,8 @@ def query_spf_record(domain, nameservers=None, resolver=None, timeout=2.0):
     if len(warnings) > 0:
         warnings_str = ". {0}".format(" ".join(warnings))
     try:
-        answers = _query_dns(domain, "TXT", nameservers=nameservers, resolver=resolver,
-                             timeout=timeout)
+        answers = _query_dns(domain, "TXT", nameservers=nameservers,
+                             resolver=resolver, timeout=timeout)
         spf_record = None
         for record in answers:
             if record.startswith("v=spf1"):
@@ -1602,8 +1623,8 @@ def query_spf_record(domain, nameservers=None, resolver=None, timeout=2.0):
     return OrderedDict([("record", spf_record), ("warnings", warnings)])
 
 
-def parse_spf_record(record, domain, parked=False, seen=None, nameservers=None, resolver=None,
-                     timeout=2.0):
+def parse_spf_record(record, domain, parked=False, seen=None, nameservers=None,
+                     resolver=None, timeout=2.0):
     """
     Parses a SPF record, including resolving ``a``, ``mx``, and ``include``
     mechanisms
@@ -1614,7 +1635,8 @@ def parse_spf_record(record, domain, parked=False, seen=None, nameservers=None, 
         parked (bool): indicated if a domain has been parked
         seen (list): A list of domains seen in past loops
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an answer from DNS
 
     Returns:
@@ -1693,8 +1715,8 @@ def parse_spf_record(record, domain, parked=False, seen=None, nameservers=None, 
             if mechanism == "a":
                 if value == "":
                     value = domain
-                a_records = _get_a_records(value, nameservers=nameservers, resolver=resolver,
-                                           timeout=timeout)
+                a_records = _get_a_records(value, nameservers=nameservers,
+                                           resolver=resolver, timeout=timeout)
                 if len(a_records) == 0:
                     raise _SPFMissingRecords(
                         "{0} does not have any A/AAAA records".format(
@@ -1705,8 +1727,8 @@ def parse_spf_record(record, domain, parked=False, seen=None, nameservers=None, 
             elif mechanism == "mx":
                 if value == "":
                     value = domain
-                mx_hosts = _get_mx_hosts(value, nameservers=nameservers, resolver=resolver,
-                                         timeout=timeout)
+                mx_hosts = _get_mx_hosts(value, nameservers=nameservers,
+                                         resolver=resolver, timeout=timeout)
                 if len(mx_hosts) == 0:
                     raise _SPFMissingRecords(
                         "{0} does not have any MX records".format(
@@ -1727,12 +1749,14 @@ def parse_spf_record(record, domain, parked=False, seen=None, nameservers=None, 
                 seen.append(value.lower())
                 try:
                     redirect_record = query_spf_record(value,
-                                                       nameservers=nameservers, resolver=resolver,
+                                                       nameservers=nameservers,
+                                                       resolver=resolver,
                                                        timeout=timeout)
                     redirect_record = redirect_record["record"]
                     redirect = parse_spf_record(redirect_record, value,
                                                 seen=seen,
-                                                nameservers=nameservers, resolver=resolver,
+                                                nameservers=nameservers,
+                                                resolver=resolver,
                                                 timeout=timeout)
                     lookup_mechanism_count += redirect["dns_lookups"]
                     if lookup_mechanism_count > 10:
@@ -1764,12 +1788,14 @@ def parse_spf_record(record, domain, parked=False, seen=None, nameservers=None, 
                 seen.append(value.lower())
                 try:
                     include_record = query_spf_record(value,
-                                                      nameservers=nameservers, resolver=resolver,
+                                                      nameservers=nameservers,
+                                                      resolver=resolver,
                                                       timeout=timeout)
                     include_record = include_record["record"]
                     include = parse_spf_record(include_record, value,
                                                seen=seen,
-                                               nameservers=nameservers, resolver=resolver,
+                                               nameservers=nameservers,
+                                               resolver=resolver,
                                                timeout=timeout)
                     lookup_mechanism_count += include["dns_lookups"]
                     if lookup_mechanism_count > 10:
@@ -1814,7 +1840,8 @@ def get_spf_record(domain, nameservers=None, resolver=None, timeout=2.0):
     Args:
         domain (str): A domain name
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): Number of seconds to wait for an answer from DNS
 
     Returns:
@@ -1828,10 +1855,11 @@ def get_spf_record(domain, nameservers=None, resolver=None, timeout=2.0):
         :exc:`checkdmarc.SPFTooManyDNSLookups`
 
     """
-    record = query_spf_record(domain, nameservers=nameservers, resolver=resolver, timeout=timeout)
+    record = query_spf_record(domain, nameservers=nameservers,
+                              resolver=resolver, timeout=timeout)
     record = record["record"]
-    parsed_record = parse_spf_record(record, domain, nameservers=nameservers, resolver=resolver,
-                                     timeout=timeout)
+    parsed_record = parse_spf_record(record, domain, nameservers=nameservers,
+                                     resolver=resolver, timeout=timeout)
     parsed_record["record"] = record
 
     return parsed_record
@@ -2080,7 +2108,8 @@ def get_mx_hosts(domain, skip_tls=False,
         approved_hostnames (list): A list of approved MX hostname substrings
         parked (bool): Indicates that the domains are parked
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an record from DNS
 
     Returns:
@@ -2097,8 +2126,8 @@ def get_mx_hosts(domain, skip_tls=False,
     warnings = []
     hostnames = set()
     dupe_hostnames = set()
-    mx_records = _get_mx_hosts(domain, nameservers=nameservers, resolver=resolver,
-                               timeout=timeout)
+    mx_records = _get_mx_hosts(domain, nameservers=nameservers,
+                               resolver=resolver, timeout=timeout)
     for record in mx_records:
         hosts.append(OrderedDict([("preference", record["preference"]),
                                   ("hostname", record["hostname"].lower()),
@@ -2134,7 +2163,8 @@ def get_mx_hosts(domain, skip_tls=False,
         try:
             host["addresses"] = []
             host["addresses"] = _get_a_records(host["hostname"],
-                                               nameservers=nameservers, resolver=resolver,
+                                               nameservers=nameservers,
+                                               resolver=resolver,
                                                timeout=timeout)
             if len(host["addresses"]) == 0:
                 warnings.append(
@@ -2151,7 +2181,8 @@ def get_mx_hosts(domain, skip_tls=False,
 
         for address in host["addresses"]:
             reverse_hostnames = _get_reverse_dns(address,
-                                                 nameservers=nameservers, resolver=resolver,
+                                                 nameservers=nameservers,
+                                                 resolver=resolver,
                                                  timeout=timeout)
             if len(reverse_hostnames) == 0:
                 warnings.append(
@@ -2214,7 +2245,8 @@ def get_nameservers(domain, approved_nameservers=None,
         domain (str): A domain name
         approved_nameservers (list): A list of approved nameserver substrings
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an record from DNS
 
     Returns:
@@ -2225,8 +2257,8 @@ def get_nameservers(domain, approved_nameservers=None,
     logging.debug("Getting NS records on {0}".format(domain))
     warnings = []
 
-    ns_records = _get_nameservers(domain, nameservers=nameservers, resolver=resolver,
-                                  timeout=timeout)
+    ns_records = _get_nameservers(domain, nameservers=nameservers,
+                                  resolver=resolver, timeout=timeout)
 
     if approved_nameservers:
         approved_nameservers = list(map(lambda h: h.lower(),
@@ -2298,7 +2330,8 @@ def check_domains(domains, parked=False,
                                                tags and/or tag values in the
                                                results
         nameservers (list): A list of nameservers to query
-        resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
+        resolver (dns.resolver.Resolver): A resolver object to use for DNS 
+                                          requests
         timeout (float): number of seconds to wait for an answer from DNS
         wait (float): number of seconds to wait between processing domains
 
@@ -2365,7 +2398,8 @@ def check_domains(domains, parked=False,
             parsed_spf = parse_spf_record(domain_results["spf"]["record"],
                                           domain_results["domain"],
                                           parked=parked,
-                                          nameservers=nameservers, resolver=resolver,
+                                          nameservers=nameservers,
+                                          resolver=resolver,
                                           timeout=timeout)
 
             domain_results["spf"]["dns_lookups"] = parsed_spf[
@@ -2386,7 +2420,8 @@ def check_domains(domains, parked=False,
                                                ("location", None)])
         try:
             dmarc_query = query_dmarc_record(domain,
-                                             nameservers=nameservers, resolver=resolver,
+                                             nameservers=nameservers,
+                                             resolver=resolver,
                                              timeout=timeout)
             domain_results["dmarc"]["record"] = dmarc_query["record"]
             domain_results["dmarc"]["location"] = dmarc_query["location"]


### PR DESCRIPTION
This MR allows passing a user defined resolver object (`dns.resolver.Resolver()`) to the DNS Requests. This is useful, when you use functions, and you want to pass special options to the resolver object.

The Settings `timeout` and `nameservers` are ignored, when a resolver is given. 

Please review or comment. I just tested it in my use case, but tried to adapt for all use cases.

I'm currently unsure how to handle the [`test_dnssec()`](https://github.com/domainaware/checkdmarc/blob/master/checkdmarc.py#L2228) function, especially the [`dns.query.udp()`](https://github.com/domainaware/checkdmarc/blob/master/checkdmarc.py#L2248) for me, it is OK to ignore it. 