### PR TITLE
Fix project.scripts setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 ]
 
 [project.scripts]
-checkdmarc = "checkdmarc.py:_main"
+checkdmarc = "checkdmarc:_main"
 
 [project.urls]
 Homepage = "https://github.com/domainaware/checkdmarc"


### PR DESCRIPTION
https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html specifies that `project.scripts` is `package.module:function`. There isn't a `py` package in a `checkdmarc` module, so this breaks the installed `bin/checkdmarc` script.

This should close #82.