### PR TITLE
Fix missing SPFSyntaxError when ip address and version are not matching

### DIFF
--- a/checkdmarc.py
+++ b/checkdmarc.py
@@ -1665,11 +1665,25 @@ def parse_spf_record(record, domain, parked=False, seen=None, nameservers=None,
         value = match[2]
 
         try:
-            if mechanism in ["ip4", "ip6"]:
+            if mechanism == "ip4":
                 try:
-                    ipaddress.ip_network(value, strict=False)
+                    if not isinstance(ipaddress.ip_network(value,
+                                                           strict=False),
+                                      ipaddress.IPv4Network):
+                        raise SPFSyntaxError("{0} is not a valid ipv4 value. "
+                                             "Looks like ipv6".format(value))
                 except ValueError:
-                    raise SPFSyntaxError("{0} is not a valid ipv4/ipv6 "
+                    raise SPFSyntaxError("{0} is not a valid ipv4 "
+                                         "value".format(value))
+            elif mechanism == "ip6":
+                try:
+                    if not isinstance(ipaddress.ip_network(value,
+                                                           strict=False),
+                                      ipaddress.IPv6Network):
+                        raise SPFSyntaxError("{0} is not a valid ipv6 value. "
+                                             "Looks like ipv4".format(value))
+                except ValueError:
+                    raise SPFSyntaxError("{0} is not a valid ipv6 "
                                          "value".format(value))
 
             if mechanism == "a":

--- a/tests.py
+++ b/tests.py
@@ -111,6 +111,13 @@ class Test(unittest.TestCase):
         self.assertRaises(checkdmarc.SPFSyntaxError,
                           checkdmarc.parse_spf_record, spf_record, domain)
 
+    def testSPFInvalidIPv6inIPv4(self):
+        """Invalid ipv4 SPF mechanism values raise SPFSyntaxError"""
+        spf_record = "v=spf1 ip4:1200:0000:AB00:1234:0000:2552:7777:1313 ~all"
+        domain = "surftown.dk"
+        self.assertRaises(checkdmarc.SPFSyntaxError,
+                          checkdmarc.parse_spf_record, spf_record, domain)
+
     def testSPFInvalidIPv4Range(self):
         """Invalid ipv4 SPF mechanism values raise SPFSyntaxError"""
         spf_record = "v=spf1 ip4:78.46.96.236/99 ~all"
@@ -121,6 +128,13 @@ class Test(unittest.TestCase):
     def testSPFInvalidIPv6(self):
         """Invalid ipv6 SPF mechanism values raise SPFSyntaxError"""
         spf_record = "v=spf1 ip6:1200:0000:AB00:1234:O000:2552:7777:1313 ~all"
+        domain = "surftown.dk"
+        self.assertRaises(checkdmarc.SPFSyntaxError,
+                          checkdmarc.parse_spf_record, spf_record, domain)
+
+    def testSPFInvalidIPv4inIPv6(self):
+        """Invalid ipv6 SPF mechanism values raise SPFSyntaxError"""
+        spf_record = "v=spf1 ip6:78.46.96.236 ~all"
         domain = "surftown.dk"
         self.assertRaises(checkdmarc.SPFSyntaxError,
                           checkdmarc.parse_spf_record, spf_record, domain)


### PR DESCRIPTION
Currently, the parse_spf_record function doesn't detect when a IPv4 Address is written in the `ip6` mechanism and the other way round. This MR will fix this behavior.