### PR TITLE
ISSUE-94: Fixing the issue with double counting void DNS lookups.

### DIFF
--- a/checkdmarc.py
+++ b/checkdmarc.py
@@ -1724,15 +1724,6 @@ def parse_spf_record(record, domain, parked=False, seen=None,
                 a_records = _get_a_records(value, nameservers=nameservers,
                                            resolver=resolver, timeout=timeout)
                 if len(a_records) == 0:
-                    void_lookup_mechanism_count += 1
-                    if void_lookup_mechanism_count > 2:
-                        raise SPFTooManyVoidDNSLookups(
-                            "Parsing the SPF record has {0}/2 maximum void "
-                            "DNS lookups - "
-                            "https://tools.ietf.org/html/rfc7208#section-4.6.4"
-                            .format(
-                                void_lookup_mechanism_count),
-                            dns_void_lookups=void_lookup_mechanism_count)
                     raise _SPFMissingRecords(
                         "{0} does not have any A/AAAA records".format(
                             value.lower()))
@@ -1745,15 +1736,6 @@ def parse_spf_record(record, domain, parked=False, seen=None,
                 mx_hosts = _get_mx_hosts(value, nameservers=nameservers,
                                          resolver=resolver, timeout=timeout)
                 if len(mx_hosts) == 0:
-                    void_lookup_mechanism_count += 1
-                    if void_lookup_mechanism_count > 2:
-                        raise SPFTooManyVoidDNSLookups(
-                            "Parsing the SPF record has {0}/2 maximum void "
-                            "DNS lookups - "
-                            "https://tools.ietf.org/html/rfc7208#section-4.6.4"
-                            .format(
-                                void_lookup_mechanism_count),
-                            dns_void_lookups=void_lookup_mechanism_count)
                     raise _SPFMissingRecords(
                         "{0} does not have any MX records".format(
                             value.lower()))


### PR DESCRIPTION
Hello,

Some time ago, I reported an issue regarding the double counting of void look-ups in checkdmarc.py (https://github.com/domainaware/checkdmarc/issues/94). Today, I investigated the matter and identified the root cause. In checkdmarc.py, specifically on lines 1727 and 1748, the variable void_lookup_mechanism_count is incremented, followed by the raising of an exception called SPFTooManyVoidDNSLookups. However, in the exception handler at line 1887, void_lookup_mechanism_count is incremented again, resulting in double counting. I remove the incrementation on lines 1727 and 1748 and let the exception handler take care of the incrementing and validation of the value of void_lookup_mechanism_count. I created and tested a number of test cases. As far as I could test everything is working perfectly now.

Best regards
Ebrahim Aharpour