### PR TITLE
Updated spf exception when spf for a domain is invalid.

### DIFF
--- a/checkdmarc.py
+++ b/checkdmarc.py
@@ -2760,7 +2760,7 @@ def check_spf(domain: str, parked: bool = False,
         spf_results["parsed"] = parsed_spf["parsed"]
         spf_results["warnings"] += parsed_spf["warnings"]
     except SPFError as error:
-        spf_results["error"] = error.args[0].args[0]
+        spf_results["error"] = error.args[0]
         del spf_results["dns_lookups"]
         spf_results["valid"] = False
         if hasattr(error, "data") and error.data:


### PR DESCRIPTION
This exception was to handle when spf is not valid. But the the line `spf_results['error'] = error.args[0].args[0]` was causing error, because `error.args[0]` returns a string where a string doesn't have `.args[0]` method.