### PR TITLE
5.0.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,6 +41,7 @@
         "maxdepth",
         "mcsv",
         "modindex",
+        "MTASTS",
         "NAMESERVER",
         "nojekyll",
         "nonauth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+5.0.1
+-----
+
+- Include MTA-STS and BIMI results in CSV output
+- Renamed `include_dmarc_tag_descriptions` parameter in `checkdmarc.check_domains()` to `include_tag_descriptions`
+- Added the `include_tag_descriptions` parameter to `checkdmarc.bimi.check_bimi()`
+- Ignore encoding value when checking the `Content-Type` header during the MTA-STS policy download
+- Added the exception class `MTASTSPolicyDownloadError`
+- Update documentation
+
 5.0.0
 -----
 

--- a/checkdmarc/_cli.py
+++ b/checkdmarc/_cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""The command line interface"""
+"""TValidates and parses email-related DNS records"""
 
 from __future__ import annotations
 
@@ -41,7 +41,7 @@ def _main():
     arg_parser.add_argument("--mx", nargs="+",
                             help="approved MX hostname substrings")
     arg_parser.add_argument("-d", "--descriptions", action="store_true",
-                            help="include descriptions of DMARC tags in "
+                            help="include descriptions of tags in "
                                  "the JSON output")
     arg_parser.add_argument("-f", "--format", default="json",
                             help="specify JSON or CSV screen output format")
@@ -96,7 +96,7 @@ def _main():
                             parked=args.parked,
                             approved_nameservers=args.ns,
                             approved_mx_hostnames=args.mx,
-                            include_dmarc_tag_descriptions=args.descriptions,
+                            include_tag_descriptions=args.descriptions,
                             nameservers=args.nameserver, timeout=args.timeout,
                             bimi_selector=args.bimi_selector,
                             wait=args.wait)

--- a/checkdmarc/_constants.py
+++ b/checkdmarc/_constants.py
@@ -18,7 +18,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 
 OS = platform.system()
 OS_RELEASE = platform.release()

--- a/checkdmarc/bimi.py
+++ b/checkdmarc/bimi.py
@@ -352,6 +352,7 @@ def parse_bimi_record(
             raise InvalidBIMITag(f"{tag} is not a valid BIMI record tag")
         tags[tag] = OrderedDict(value=tag_value)
         if include_tag_descriptions:
+            tags[tag]["name"] = bimi_tags[tag]["name"]
             tags[tag]["description"] = bimi_tags[tag]["description"]
         if tag == "a" and tag_value != "":
             try:
@@ -372,6 +373,7 @@ def parse_bimi_record(
 
 
 def check_bimi(domain: str, selector: str = "default",
+               include_tag_descriptions: bool = False,
                nameservers: list[str] = None,
                resolver: dns.resolver.Resolver = None,
                timeout: float = 2.0) -> OrderedDict:
@@ -386,6 +388,7 @@ def check_bimi(domain: str, selector: str = "default",
     Args:
         domain (str): A domain name
         selector (str): The BIMI selector
+        include_tag_descriptions (bool): Include descriptions in parsed results
         nameservers (list): A list of nameservers to query
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
@@ -415,7 +418,9 @@ def check_bimi(domain: str, selector: str = "default",
             timeout=timeout)
         bimi_results["selector"] = selector
         bimi_results["record"] = bimi_query["record"]
-        parsed_bimi = parse_bimi_record(bimi_results["record"])
+        parsed_bimi = parse_bimi_record(
+            bimi_results["record"],
+            include_tag_descriptions=include_tag_descriptions)
         bimi_results["tags"] = parsed_bimi["tags"]
         bimi_results["warnings"] = parsed_bimi["warnings"]
     except BIMIError as error:

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -1,7 +1,57 @@
 # API
 
+## checkdmarc
+
 ```{eval-rst}
 .. automodule:: checkdmarc
    :members:
-   :undoc-members:
+```
+
+## checkdmarc.bimi
+
+```{eval-rst}
+.. automodule:: checkdmarc.bimi
+   :members:
+```
+
+## checkdmarc.dmarc
+
+```{eval-rst}
+.. automodule:: checkdmarc.dmarc
+   :members:
+```
+
+## checkdmarc.dnssec
+
+```{eval-rst}
+.. automodule:: checkdmarc.dnssec
+   :members:
+```
+
+## checkdmarc.mta_sts
+
+```{eval-rst}
+.. automodule:: checkdmarc.mta_sts
+   :members:
+```
+
+## checkdmarc.smtp
+
+```{eval-rst}
+.. automodule:: checkdmarc.smtp
+   :members:
+```
+
+## checkdmarc.spf
+
+```{eval-rst}
+.. automodule:: checkdmarc.spf
+   :members:
+```
+
+## checkdmarc.utils
+
+```{eval-rst}
+.. automodule:: checkdmarc.utils
+   :members:
 ```

--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -1,39 +1,36 @@
 # CLI
 
 ```text
-usage: checkdmarc  [-h] [-p] [--ns NS [NS ...]] [--mx MX [MX ...]] [-d]
-                    [-f FORMAT] [-o OUTPUT [OUTPUT ...]]
-                    [-n NAMESERVER [NAMESERVER ...]] [-t TIMEOUT] [-v]
-                    [-w WAIT] [--skip-tls] [--debug]
-                    domain [domain ...]
+usage: checkdmarc [-h] [-p] [--ns NS [NS ...]] [--mx MX [MX ...]] [-d] [-f FORMAT] [-o OUTPUT [OUTPUT ...]]
+                  [-n NAMESERVER [NAMESERVER ...]] [-t TIMEOUT] [-b BIMI_SELECTOR] [-v] [-w WAIT] [--skip-tls]
+                  [--debug]
+                  domain [domain ...]
 
-  Validates and parses SPF amd DMARC DNS records
+Validates and parses email-related DNS records
 
-  positional arguments:
-    domain                one or more domains, or a single path to a file
-                          containing a list of domains
+positional arguments:
+  domain                one or more domains, or a single path to a file containing a list of domains
 
-  optional arguments:
-    -h, --help            show this help message and exit
-    -p, --parked          indicate that the domains are parked
-    --ns NS [NS ...]      approved nameserver substrings
-    --mx MX [MX ...]      approved MX hostname substrings
-    -d, --descriptions    include descriptions of DMARC tags in the JSON output
-    -f FORMAT, --format FORMAT
-                          specify JSON or CSV screen output format
-    -o OUTPUT [OUTPUT ...], --output OUTPUT [OUTPUT ...]
-                          one or more file paths to output to (must end in .json
-                          or .csv) (silences screen output)
-    -n NAMESERVER [NAMESERVER ...], --nameserver NAMESERVER [NAMESERVER ...]
-                          nameservers to query (Default is Cloudflare's
-    -t TIMEOUT, --timeout TIMEOUT
-                          number of seconds to wait for an answer from DNS
-                          (default 2.0)
-    -v, --version         show program's version number and exit
-    -w WAIT, --wait WAIT  number of seconds to wait between checking domains
-                          (default 0.0)
-    --skip-tls            skip TLS/SSL testing
-    --debug               enable debugging output
+options:
+  -h, --help            show this help message and exit
+  -p, --parked          indicate that the domains are parked
+  --ns NS [NS ...]      approved nameserver substrings
+  --mx MX [MX ...]      approved MX hostname substrings
+  -d, --descriptions    include descriptions of tags in the JSON output
+  -f FORMAT, --format FORMAT
+                        specify JSON or CSV screen output format
+  -o OUTPUT [OUTPUT ...], --output OUTPUT [OUTPUT ...]
+                        one or more file paths to output to (must end in .json or .csv) (silences screen output)
+  -n NAMESERVER [NAMESERVER ...], --nameserver NAMESERVER [NAMESERVER ...]
+                        nameservers to query
+  -t TIMEOUT, --timeout TIMEOUT
+                        number of seconds to wait for an answer from DNS (default 2.0)
+  -b BIMI_SELECTOR, --bimi-selector BIMI_SELECTOR
+                        Check for a BIMI record at the provided selector
+  -v, --version         show program's version number and exit
+  -w WAIT, --wait WAIT  number of seconds to wait between checking domains (default 0.0)
+  --skip-tls            skip TLS/SSL testing
+  --debug               enable debugging output
 ```
 
 ## Example

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -20,7 +20,7 @@
 
 ```{toctree}
 ---
-maxdepth: 2
+maxdepth: 1
 ---
 installation
 api


### PR DESCRIPTION
- Include MTA-STS and BIMI results in CSV output
- Renamed `include_dmarc_tag_descriptions` parameter in `checkdmarc.check_domains()` to `include_tag_descriptions`
- Added the `include_tag_descriptions` parameter to `checkdmarc.bimi.check_bimi()`
- Ignore encoding value when checking the `Content-Type` header during the MTA-STS policy download
- Added the exception class `MTASTSPolicyDownloadError`
- Update documentation