### PR TITLE
Issue #136 - Bugfix test_dnssec method cache

### DIFF
--- a/checkdmarc/dnssec.py
+++ b/checkdmarc/dnssec.py
@@ -106,7 +106,7 @@ def test_dnssec(domain: str,
         cache = DNSSEC_CACHE
 
     if domain in cache:
-        return DNSSEC_CACHE[cache]
+        return cache[domain]
 
     key = get_dnskey(domain, nameservers=nameservers, timeout=timeout)
     if key is None:


### PR DESCRIPTION
https://github.com/domainaware/checkdmarc/blob/3d3da6edee43f2b03c28d0747c95f202be25fd92/checkdmarc/dnssec.py#L109

This line is attempting to access a cache within a cache. This throws an `unhashable type: 'ExpiringDict'` error. 

This PR proposes replacing that with the following

```
  if domain in cache:
      return cache[domain]
```

Which is identical to what is used by the `get_dnskey` method on [line 57](https://github.com/domainaware/checkdmarc/blob/3d3da6edee43f2b03c28d0747c95f202be25fd92/checkdmarc/dnssec.py#L57)