### PR TITLE
Fixed checking whether there is some text after 'all' directive

### DIFF
--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -39,7 +39,7 @@ SPF_MECHANISM_REGEX_STRING = (
     r"([+\-~?])?(mx|ip4|ip6|exists|include|all|a|redirect|exp|ptr)"
     r"[:=]?([\w+/_.:\-{%}]*)"
 )
-AFTER_ALL_REGEX_STRING = "all .*"
+AFTER_ALL_REGEX_STRING = r"\ball\s*[^\s]+"
 
 SPF_MECHANISM_REGEX = re.compile(SPF_MECHANISM_REGEX_STRING, re.IGNORECASE)
 AFTER_ALL_REGEX = re.compile(AFTER_ALL_REGEX_STRING, re.IGNORECASE)


### PR DESCRIPTION
This solves the case when e.g. there is some whitespace after ~all