### PR TITLE
Fix SPF Record verification failing for domains with a label starting with "all" (#145)

### DIFF
--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -40,7 +40,7 @@ SPF_MECHANISM_REGEX_STRING = (
     r"(mx:?|ip4:?|ip6:?|exists:?|include:?|all:?|a:?|redirect=|exp:?|ptr:?)"
     r"([\w+/_.:\-{%}]*)"
 )
-AFTER_ALL_REGEX_STRING = r"([\s^][+\-~?]?all)\s+[^\s]+"
+AFTER_ALL_REGEX_STRING = r"([\s^][+\-~?]?all)\s+.*"
 
 SPF_MECHANISM_REGEX = re.compile(SPF_MECHANISM_REGEX_STRING, re.IGNORECASE)
 AFTER_ALL_REGEX = re.compile(AFTER_ALL_REGEX_STRING, re.IGNORECASE)

--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -40,7 +40,7 @@ SPF_MECHANISM_REGEX_STRING = (
     r"(mx:?|ip4:?|ip6:?|exists:?|include:?|all:?|a:?|redirect=|exp:?|ptr:?)"
     r"([\w+/_.:\-{%}]*)"
 )
-AFTER_ALL_REGEX_STRING = r"\ball\s*[^\s]+"
+AFTER_ALL_REGEX_STRING = r"([\s^][+\-~?]?all)\s+[^\s]+"
 
 SPF_MECHANISM_REGEX = re.compile(SPF_MECHANISM_REGEX_STRING, re.IGNORECASE)
 AFTER_ALL_REGEX = re.compile(AFTER_ALL_REGEX_STRING, re.IGNORECASE)
@@ -253,7 +253,7 @@ def parse_spf_record(
                             f"{correct_record} not: {record}")
     if len(AFTER_ALL_REGEX.findall(record)) > 0:
         warnings.append("Any text after the all mechanism is ignored")
-        record = AFTER_ALL_REGEX.sub("all", record)
+        record = AFTER_ALL_REGEX.sub(r"\1", record)
     parsed_record = spf_syntax_checker.parse(record)
     if not parsed_record.is_valid:
         pos = parsed_record.pos


### PR DESCRIPTION
Hello ! There is already an issue and a commit for this bug (https://github.com/ricco386/checkdmarc/commit/26906274402a84f35431b5c970c4e99dd777fe17), but I discovered it independently and came up with a more complete fix.

My solution ensures that, if .all ever becomes a valid TLD, the parsing won't stop working again, because it ensures that what we're matching is really an `all` mechanism and not part of some other mechanism.

It also fixes another bug : the current regex only matches one term after the `all`, so multiple "trailing" terms or random text with spaces are not ignored properly.