### PR TITLE
fix discrepencies on http_timeout usage

### DIFF
--- a/checkdmarc/mta_sts.py
+++ b/checkdmarc/mta_sts.py
@@ -470,7 +470,7 @@ def check_mta_sts(
         warnings = mta_sts_record["warnings"]
         mta_sts_record = parse_mta_sts_record(mta_sts_record["record"])
         mta_sts_results["id"] = mta_sts_record["tags"]["id"]["value"]
-        policy = download_mta_sts_policy(domain, timeout=timeout)
+        policy = download_mta_sts_policy(domain, http_timeout=timeout)
         warnings += policy["warnings"]
         policy = parse_mta_sts_policy(policy["policy"])
         warnings += policy["warnings"]


### PR DESCRIPTION
`download_mta_sts_policy` accepts a `http_timeout` parameter but a `timeout` parameter was provided:

https://github.com/domainaware/checkdmarc/blob/e3543866a9b0c6dacc99e64f15fb857de155d500/checkdmarc/mta_sts.py#L473

Therefore, running `checkdmarc.check_domains(domains=['some-amazing-domain.com'])` led to a TypeError exception:
```
TypeError: download_mta_sts_policy() got an unexpected keyword argument 'timeout'`)
```
This was reported in #165 

The fix updates the parameter `timeout` to fit the expected name.

It is unclear if a distinct `http_timeout` parameter should be introduced as well in `check_domains`, then in `check_mta_sts`.