### PR TITLE
Updated dependencies to allow cryptography 46 to be used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "dnspython>=2.0.0",
-    "cryptography~=45.0",
+    "cryptography>=45.0,<47.0",
     "pyopenssl>=24.2.1",
     "pem>=23.1.0",
     "expiringdict>=1.1.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dnspython>=2.0.0
-cryptography~=45.0
+cryptography>=45.0,<47.0
 pem>=23.1.0
 expiringdict>=1.1.4
 pyleri>=1.3.2


### PR DESCRIPTION
Changed dependency range for cryptography to also allow versions 46.* to be used (in addition to 45.*).

All tests passed with 46.0.0 and 46.0.1. Furthermore, none of the removed (previously deprecated) functions and classes are used by checkdmarc. https://cryptography.io/en/46.0.1/changelog/