### PR TITLE
Remove return statement from the finally block

### DIFF
--- a/checkdmarc/smtp.py
+++ b/checkdmarc/smtp.py
@@ -123,8 +123,7 @@ def test_tls(
             server.close()
         except Exception as e:
             logging.debug(e)
-        finally:
-            return tls
+        return tls
 
     except socket.gaierror:
         error = "DNS resolution failed"


### PR DESCRIPTION
I assume the intention here wasn't to swallow BaseException so I've removed the return statements from the finally block without changing the Exception to BaseException.

This removes the following SyntaxWarnings in Python 3.14:

```
/Users/anzepecar/code/checkdmarc-test/.venv/lib/python3.14/site-packages/checkdmarc/smtp.py:127: SyntaxWarning: 'return' in a 'finally' block
  return tls
/Users/anzepecar/code/checkdmarc-test/.venv/lib/python3.14/site-packages/checkdmarc/smtp.py:200: SyntaxWarning: 'return' in a 'finally' block
  return tls
/Users/anzepecar/code/checkdmarc-test/.venv/lib/python3.14/site-packages/checkdmarc/smtp.py:249: SyntaxWarning: 'return' in a 'finally' block
  return starttls
```

More info on why return/break/continue are no longer allowed in finally statements [are in this PEP](https://peps.python.org/pep-0765/).