### PR TITLE
Validate DMARC sp tag like p tag (fixes #207)

### DIFF
--- a/checkdmarc/dmarc.py
+++ b/checkdmarc/dmarc.py
@@ -374,6 +374,38 @@ dmarc_tags = OrderedDict(
         'specified by the "p" '
         "tag MUST be applied "
         "for subdomains.",
+        values={
+            "none": "The Domain Owner requests "
+            "no specific action be "
+            "taken regarding delivery "
+            "of messages.",
+            "quarantine": "The Domain Owner "
+            "wishes to have "
+            "email that fails "
+            "the DMARC mechanism "
+            "check be treated by "
+            "Mail Receivers as "
+            "suspicious. "
+            "Depending on the "
+            "capabilities of the "
+            "MailReceiver, "
+            "this can mean "
+            '"place into spam '
+            'folder", '
+            '"scrutinize '
+            "with additional "
+            'intensity", and/or '
+            '"flag as '
+            'suspicious".',
+            "reject": "The Domain Owner wishes "
+            "for Mail Receivers to "
+            "reject "
+            "email that fails the "
+            "DMARC mechanism check. "
+            "Rejection SHOULD "
+            "occur during the SMTP "
+            "transaction.",
+        },
     ),
     v=OrderedDict(
         name="Version",
@@ -937,6 +969,8 @@ def parse_dmarc_record(
     tags["p"]["value"] = tags["p"]["value"].lower()
     if "sp" not in tags:
         tags["sp"] = OrderedDict([("value", tags["p"]["value"]), ("explicit", False)])
+    # Normalize sp value for validation consistency (mirrors p behavior)
+    tags["sp"]["value"] = tags["sp"]["value"].lower()
     if list(tags.keys())[1] != "p":
         raise DMARCSyntaxError("the p tag must immediately follow the v tag.")
     tags["v"]["value"] = tags["v"]["value"].upper()


### PR DESCRIPTION
## Summary

This PR fixes an issue where the DMARC `sp` tag accepts invalid values without failing validation, as described in #207.

Currently, the `p` tag is validated correctly and causes validation to fail when it has an invalid value, but the `sp` tag is only parsed and passed through, even if its value is not one of the allowed DMARC policy values.

