### PR TITLE
Reject SPF records with concatenated 'all' mechanisms without whitesp…

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -261,6 +261,18 @@ class Test(unittest.TestCase):
             domain,
         )
 
+    def testSPFInvalidMissingSpaceBeforeAllMechanism(self):
+        """There is not a space between the IP4 and all mechanism in the SPF record."""
+        spf_record = "v=spf1 ip4:8.8.8.8~all"
+        domain = "example.com"
+
+        self.assertRaises(
+            checkdmarc.spf.SPFSyntaxError,
+            checkdmarc.spf.parse_spf_record,
+            spf_record,
+            domain,
+        )
+
     def testSPFIncludeLoop(self):
         """SPF record with include loop raises SPFIncludeLoop"""
 


### PR DESCRIPTION
# Summary
This pull request fixes incorrect acceptance of SPF records where the all mechanism is concatenated to the preceding term without a required space, such as:
```
v=spf1 ip4:203.0.113.7~all
```
Per RFC 7208, SPF terms must be whitespace-separated, so these records should be treated as syntax errors rather than being silently accepted.
## What this change does
Detects cases where an all mechanism is “glued” to the previous term (e.g., ip4:8.8.8.8~all) instead of being separated by whitespace.
Validates that the qualifier (+, -, ~, ?) immediately precedes all and that all ends the term, to avoid false positives on legitimate hostnames or labels containing -all.
Raises a clear SPFSyntaxError indicating the position in the record where whitespace is expected before all, including a marker to make the problem visually obvious.
Keeps the grammar permissive regarding whitespace, and performs this whitespace separation check in Python before running the main SPF parser.
## Motivation / Issue
This addresses [#209](https://github.com/domainaware/checkdmarc/issues/209), where SPF records missing a space before the all mechanism were not being rejected despite being syntactically invalid according to the specification.
Behavioral impact
With this change, SPF records that previously passed despite a missing space before all will now fail with a syntax error, making validation stricter and more aligned with RFC 7208 and real-world expectations.