### PR TITLE
Fix uncaught ValueError and incorrect PTR void lookup handling

### DIFF
--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -957,19 +957,6 @@ def parse_spf_record(
             elif mechanism == "ptr":
                 mechanism_dns_lookups += 1
                 total_dns_lookups += 1
-                a_records = get_a_records(
-                    value,
-                    nameservers=nameservers,
-                    resolver=resolver,
-                    timeout=timeout,
-                    timeout_retries=timeout_retries,
-                )
-                if len(a_records) == 0:
-                    # Do not pre-increment void counters here; let the outer
-                    # handler for _SPFMissingRecords account for a single void lookup.
-                    raise _SPFMissingRecords(
-                        f"A ptr mechanism points to {value.lower()}, but that domain/subdomain does not have any A/AAAA records."
-                    )
                 parsed["mechanisms"].append(
                     OrderedDict(
                         [


### PR DESCRIPTION
## Summary

This pull request fixes two regressions introduced in the latest release:

1. Multiple `all` mechanisms raised an uncaught `ValueError`
2. PTR mechanisms incorrectly counted missing A records as void lookups, causing valid SPF records to be rejected

Both fixes restore correct SPF parsing behavior and align with the SPF specification.

---

## 1. Uncaught `ValueError` when SPF record contains multiple `all` mechanisms

In the recent release, an SPF record containing two `all` mechanisms caused the parser to raise a raw `ValueError` instead of a proper syntax error.

**Example domain:**  
- `invalid-double-all.spf-test2.nestous.eu`

This should be treated as a syntax error, but the unhandled exception bypassed normal error-handling logic.

**Fix:**  
Replaced the `ValueError` with `SPFSyntaxError` so the parser reports the error consistently and gracefully.

---

## 2. PTR mechanism incorrectly increments void lookup count

The latest release performs an `A` lookup during `ptr` mechanism evaluation and counts a missing A record as a void lookup. This behavior is incorrect and caused valid SPF records to be flagged as invalid.

**Example domain:**  
- `valid2.spf-test.nestous.eu`

This record includes a `ptr` mechanism whose referenced domain lacks an A record — which is a valid and common scenario. The erroneous void-lookup increment could cause a valid SPF record with two legitimate void lookups to be rejected.

**Fix:**  
Removed the A-record-based void lookup increment for the PTR mechanism.  
PTR arguments are now validated syntactically without DNS resolution, restoring correct behavior.

---

## Tests

All existing tests pass.  
Please let me know if you'd like test cases added using the domains referenced above.

---

Thanks for reviewing, and for your continued work on this project.
