### PR TITLE
Correctly handle and validate SPF macros in mechanisms and modifiers

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -411,6 +411,140 @@ class Test(unittest.TestCase):
 
         self.assertEqual(len(results["warnings"]), 0)
 
+    def testSPFValidAMechanismMacro(self):
+        """SPF records with valid macros are accepted"""
+        spf_record = "v=spf1 a:%{l}.example.com -all"
+        domain = "example.com"
+        results = checkdmarc.spf.parse_spf_record(spf_record, domain)
+        self.assertIn("mechanisms", results["parsed"])
+        self.assertEqual(len(results["warnings"]), 0)
+
+    def testSPFBrokenAMechanismMacro(self):
+        """SPF records with invalid macros raise SPFSyntaxError"""
+        spf_record = "v=spf1 a:%{?} -all"
+        domain = "example.com"
+        self.assertRaises(
+            checkdmarc.spf.SPFSyntaxError,
+            checkdmarc.spf.parse_spf_record,
+            spf_record,
+            domain,
+        )
+
+    def testSPFValidMXMechanismMacro(self):
+        """SPF records with valid macros in mx mechanism are accepted"""
+        spf_record = "v=spf1 mx:%{d} -all"
+        domain = "example.com"
+        results = checkdmarc.spf.parse_spf_record(spf_record, domain)
+        self.assertIn("mechanisms", results["parsed"])
+        self.assertEqual(len(results["warnings"]), 0)
+
+    def testSPFBrokenMXMechanismMacro(self):
+        """SPF records with invalid macros in mx mechanism raise SPFSyntaxError"""
+        spf_record = "v=spf1 mx:%{?} -all"
+        domain = "example.com"
+        self.assertRaises(
+            checkdmarc.spf.SPFSyntaxError,
+            checkdmarc.spf.parse_spf_record,
+            spf_record,
+            domain,
+        )
+
+    def testSPFValidPTRMechanismMacro(self):
+        """SPF records with valid macros in ptr mechanism are accepted (but warn about ptr usage)"""
+        spf_record = "v=spf1 ptr:%{d} -all"
+        domain = "example.com"
+        results = checkdmarc.spf.parse_spf_record(spf_record, domain)
+        self.assertIn("mechanisms", results["parsed"])
+        # PTR mechanism always raises a warning in checkdmarc
+        self.assertTrue(any("ptr mechanism should not be used" in w for w in results["warnings"]))
+
+    def testSPFBrokenPTRMechanismMacro(self):
+        """SPF records with invalid macros in ptr mechanism raise SPFSyntaxError"""
+        spf_record = "v=spf1 ptr:%{?} -all"
+        domain = "example.com"
+        self.assertRaises(
+            checkdmarc.spf.SPFSyntaxError,
+            checkdmarc.spf.parse_spf_record,
+            spf_record,
+            domain,
+        )
+
+    def testSPFValidIncludeMechanismMacro(self):
+        """SPF records with valid macros in include mechanism are accepted"""
+        spf_record = "v=spf1 include:%{d}._spf.example.com -all"
+        domain = "example.com"
+        results = checkdmarc.spf.parse_spf_record(spf_record, domain)
+        self.assertIn("mechanisms", results["parsed"])
+        self.assertEqual(len(results["warnings"]), 0)
+
+    def testSPFBrokenIncludeMechanismMacro(self):
+        """SPF records with invalid macros in include mechanism raise SPFSyntaxError"""
+        spf_record = "v=spf1 include:%{?}._spf.example.com -all"
+        domain = "example.com"
+        self.assertRaises(
+            checkdmarc.spf.SPFSyntaxError,
+            checkdmarc.spf.parse_spf_record,
+            spf_record,
+            domain,
+        )
+
+    def testSPFValidExistsMechanismMacro(self):
+        """SPF records with valid macros in exists mechanism are accepted"""
+        spf_record = "v=spf1 exists:%{i}._spf.example.com -all"
+        domain = "example.com"
+        results = checkdmarc.spf.parse_spf_record(spf_record, domain)
+        self.assertIn("mechanisms", results["parsed"])
+        self.assertEqual(len(results["warnings"]), 0)
+
+    def testSPFBrokenExistsMechanismMacro(self):
+        """SPF records with invalid macros in exists mechanism raise SPFSyntaxError"""
+        spf_record = "v=spf1 exists:%{?}._spf.example.com -all"
+        domain = "example.com"
+        self.assertRaises(
+            checkdmarc.spf.SPFSyntaxError,
+            checkdmarc.spf.parse_spf_record,
+            spf_record,
+            domain,
+        )
+
+    def testSPFValidRedirectModifierMacro(self):
+        """SPF records with valid macros in redirect modifier are accepted"""
+        spf_record = "v=spf1 redirect=%{d}._spf.example.com"
+        domain = "example.com"
+        results = checkdmarc.spf.parse_spf_record(spf_record, domain)
+        self.assertIn("redirect", results["parsed"])
+        self.assertEqual(len(results["warnings"]), 0)
+
+    def testSPFBrokenRedirectModifierMacro(self):
+        """SPF records with invalid macros in redirect modifier raise SPFSyntaxError"""
+        spf_record = "v=spf1 redirect=%{?}._spf.example.com"
+        domain = "example.com"
+        self.assertRaises(
+            checkdmarc.spf.SPFSyntaxError,
+            checkdmarc.spf.parse_spf_record,
+            spf_record,
+            domain,
+        )
+
+    def testSPFValidExpModifierMacro(self):
+        """SPF records with valid macros in exp modifier are accepted"""
+        spf_record = "v=spf1 -all exp=%{d}"
+        domain = "example.com"
+        results = checkdmarc.spf.parse_spf_record(spf_record, domain)
+        self.assertIn("exp", results["parsed"])
+        self.assertEqual(len(results["warnings"]), 0)
+
+    def testSPFBrokenExpModifierMacro(self):
+        """SPF records with invalid macros in exp modifier raise SPFSyntaxError"""
+        spf_record = "v=spf1 -all exp=%{?}"
+        domain = "example.com"
+        self.assertRaises(
+            checkdmarc.spf.SPFSyntaxError,
+            checkdmarc.spf.parse_spf_record,
+            spf_record,
+            domain,
+        )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
#### Description
This PR improves the handling of SPF macros within `checkdmarc`. Previously, the parser attempted to resolve DNS records for mechanisms containing macros (e.g., `a:%{d}`), which would fail or produce incorrect results since macros require runtime context (like the sender's IP or domain) to be expanded.

This update ensures that when a macro is detected in a mechanism or modifier, `checkdmarc` validates the macro's syntax but skips the associated DNS lookup.

#### Changes
*   **`checkdmarc/spf.py`**:
    *   Added logic to detect macros (presence of `%`) in `a`, `mx`, `include`, `ptr`, `exists` mechanisms and `redirect`, `exp` modifiers.
    *   Implemented syntax validation for these macros using `_validate_spf_macros`.
    *   Prevented DNS lookups for `a`, `mx`, `include`, `redirect`, and `exp` when macros are present, treating them as valid but unresolvable in a static context.
    *   Ensured these mechanisms are still included in the `parsed` output.

*   **`tests.py`**:
    *   Added a comprehensive set of unit tests covering both valid and invalid macro syntax for all supported mechanisms:
        *   `a`: `testSPFValidAMechanismMacro`, `testSPFBrokenAMechanismMacro`
        *   `mx`: `testSPFValidMXMechanismMacro`, `testSPFBrokenMXMechanismMacro`
        *   `ptr`: `testSPFValidPTRMechanismMacro`, `testSPFBrokenPTRMechanismMacro`
        *   `include`: `testSPFValidIncludeMechanismMacro`, `testSPFBrokenIncludeMechanismMacro`
        *   `exists`: `testSPFValidExistsMechanismMacro`, `testSPFBrokenExistsMechanismMacro`
        *   `redirect`: `testSPFValidRedirectModifierMacro`, `testSPFBrokenRedirectModifierMacro`
        *   `exp`: `testSPFValidExpModifierMacro`, `testSPFBrokenExpModifierMacro`

#### Motivation
SPF macros (RFC 7208) allow for dynamic policy records. A static analyzer like `checkdmarc` cannot resolve these dynamic values. Attempting to do so leads to `NXDOMAIN` errors or meaningless queries (e.g., looking up `%{i}.example.com`). This change aligns the parser's behavior with the limitations of static analysis by validating the syntax without performing the impossible resolution.