### PR TITLE
DNS retries, failover, and timeout centralization (5.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 5.15.0
+
+### Changes (breaking)
+
+- Rename the `timeout_retries` kwarg to `retries` across all public APIs, and
+  rename the CLI flag `--timeout-retries` to `--retries`. The retry logic now
+  covers transient failures beyond timeouts — `dns.resolver.LifetimeTimeout`,
+  `dns.resolver.NoNameservers` (typically a SERVFAIL from upstream), and
+  `OSError` during TCP fallback. `NXDOMAIN` and `NoAnswer` remain
+  non-retryable (definitive negative answers).
+- Change the default retry count from `2` to `0`. The retry loop tripled
+  worst-case query time without helping when stalls were caused by
+  misbehaving authoritative nameservers. Callers that want retries can pass
+  `retries=2` or use `--retries 2` on the CLI.
+- Cap the per-nameserver query budget at `min(1.0, timeout)` seconds, with
+  an overall `lifetime = timeout * len(nameservers)`. When multiple
+  nameservers are configured, dnspython now falls through to the next one
+  after at most 1s instead of letting a single slow or broken nameserver
+  consume the whole lifetime before any fallback is attempted. Failover
+  across the configured list happens inside each attempt; `retries` retries
+  the whole attempt after all configured nameservers have been tried.
+- Default to a mix of public DNS providers (`1.1.1.1`, `8.8.8.8`) when no
+  nameservers are passed, instead of falling back to `/etc/resolv.conf`.
+  Combined with the per-nameserver cap above, this gives cross-provider
+  failover out of the box — a slow or broken path at one resolver falls
+  through to the other within ~1s. Exposed as
+  `checkdmarc._constants.DEFAULT_DNS_NAMESERVERS`. Users that need
+  system-configured or internal resolvers can still pass them explicitly
+  via `nameservers=...` or `--nameserver`.
+- Centralize default timeouts and retry counts as constants in
+  `checkdmarc._constants` (`DEFAULT_DNS_TIMEOUT`, `DEFAULT_DNS_MAX_RETRIES`,
+  `DEFAULT_SMTP_TIMEOUT`), matching the existing `DEFAULT_HTTP_TIMEOUT`
+  pattern. Function defaults now reference these constants so tuning is a
+  one-file change.
+
 ## 5.14.3
 
 ### Fixes

--- a/checkdmarc/__init__.py
+++ b/checkdmarc/__init__.py
@@ -16,6 +16,7 @@ import dns.resolver
 from dns.nameserver import Nameserver
 
 import checkdmarc._constants
+from checkdmarc._constants import DEFAULT_DNS_TIMEOUT, DEFAULT_DNS_MAX_RETRIES
 from checkdmarc.bimi import check_bimi, BIMICheckResult
 from checkdmarc.dmarc import check_dmarc, DMARCResults, DMARCErrorResults
 from checkdmarc.dnssec import test_dnssec
@@ -87,8 +88,8 @@ def check_domains(
     include_tag_descriptions: bool = False,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
     wait: float = 0.0,
 ) -> Union[DomainCheckResult, list[DomainCheckResult]]:
     """
@@ -109,7 +110,7 @@ def check_domains(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
         wait (float): number of seconds to wait between processing domains
 
     Returns:
@@ -175,7 +176,7 @@ def check_domains(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
 
         mta_sts_mx_patterns = None
@@ -184,7 +185,7 @@ def check_domains(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         domain_results["mta_sts"] = mta_sts_result
         if mta_sts_result["valid"] is True:
@@ -197,7 +198,7 @@ def check_domains(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
 
         domain_results["spf"] = check_spf(
@@ -206,7 +207,7 @@ def check_domains(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
 
         domain_results["dmarc"] = check_dmarc(
@@ -216,7 +217,7 @@ def check_domains(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
 
         domain_results["smtp_tls_reporting"] = check_smtp_tls_reporting(
@@ -224,7 +225,7 @@ def check_domains(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         if bimi_selector is not None:
             domain_results["bimi"] = check_bimi(
@@ -235,7 +236,7 @@ def check_domains(
                 nameservers=nameservers,
                 resolver=resolver,
                 timeout=timeout,
-                timeout_retries=timeout_retries,
+                retries=retries,
             )
 
         results.append(domain_results)
@@ -254,8 +255,8 @@ def check_ns(
     approved_nameservers: Optional[Sequence[str | Nameserver]] = None,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> NameserverResult:
     """
     Returns a dictionary of nameservers and warnings or a dictionary with an
@@ -287,7 +288,7 @@ def check_ns(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
     except DNSException as error:
         ns_error: NameserverResultError = {

--- a/checkdmarc/_cli.py
+++ b/checkdmarc/_cli.py
@@ -9,6 +9,11 @@ from argparse import ArgumentParser
 
 import logging
 
+from checkdmarc._constants import (
+    DEFAULT_DNS_MAX_RETRIES,
+    DEFAULT_DNS_NAMESERVERS,
+    DEFAULT_DNS_TIMEOUT,
+)
 from checkdmarc import (
     __version__,
     check_domains,
@@ -71,20 +76,29 @@ def _main():
         "(silences screen output)",
     )
     arg_parser.add_argument(
-        "-n", "--nameserver", nargs="+", help="nameservers to query"
+        "-n",
+        "--nameserver",
+        nargs="+",
+        help=(f"nameservers to query (default: {' '.join(DEFAULT_DNS_NAMESERVERS)})"),
     )
     arg_parser.add_argument(
         "-t",
         "--timeout",
-        help="number of seconds to wait for an answer from DNS (default 2.0)",
+        help=(
+            "number of seconds to wait for an answer from DNS "
+            f"(default {DEFAULT_DNS_TIMEOUT})"
+        ),
         type=float,
-        default=2.0,
+        default=DEFAULT_DNS_TIMEOUT,
     )
     arg_parser.add_argument(
-        "--timeout-retries",
-        help="number of times to reattempt a query after a timeout (default 2)",
+        "--retries",
+        help=(
+            "number of times to retry on timeout or other transient errors "
+            f"(default {DEFAULT_DNS_MAX_RETRIES})"
+        ),
         type=int,
-        default=2,
+        default=DEFAULT_DNS_MAX_RETRIES,
     )
 
     arg_parser.add_argument(
@@ -142,7 +156,7 @@ def _main():
         include_tag_descriptions=args.descriptions,
         nameservers=args.nameserver,
         timeout=args.timeout,
-        timeout_retries=args.timeout_retries,
+        retries=args.retries,
         bimi_selector=args.bimi_selector,
         wait=args.wait,
     )

--- a/checkdmarc/_constants.py
+++ b/checkdmarc/_constants.py
@@ -19,13 +19,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-__version__ = "5.14.3"
+__version__ = "5.15.0"
 
 OS = platform.system()
 OS_RELEASE = platform.release()
 USER_AGENT = f"Mozilla/5.0 (({OS} {OS_RELEASE})) checkdmarc/{__version__}"
 SYNTAX_ERROR_MARKER = "➞"
 DEFAULT_HTTP_TIMEOUT = 2.0
+DEFAULT_DNS_TIMEOUT = 2.0
+DEFAULT_DNS_MAX_RETRIES = 0
+# Mix providers so a single operator's anycast outage or authoritative-server
+# incompatibility (e.g. Cloudflare's QNAME minimization vs. certain auth
+# servers) falls through to a different provider within one resolve() call.
+DEFAULT_DNS_NAMESERVERS = ("1.1.1.1", "8.8.8.8")
+DEFAULT_SMTP_TIMEOUT = 5.0
 CACHE_MAX_LEN = 200000
 CACHE_MAX_AGE_SECONDS = 1800
 

--- a/checkdmarc/bimi.py
+++ b/checkdmarc/bimi.py
@@ -43,7 +43,13 @@ from cryptography.x509.verification import (
 import pyleri
 
 import checkdmarc.resources
-from checkdmarc._constants import DEFAULT_HTTP_TIMEOUT, SYNTAX_ERROR_MARKER, USER_AGENT
+from checkdmarc._constants import (
+    DEFAULT_DNS_TIMEOUT,
+    DEFAULT_DNS_MAX_RETRIES,
+    DEFAULT_HTTP_TIMEOUT,
+    SYNTAX_ERROR_MARKER,
+    USER_AGENT,
+)
 from checkdmarc.dmarc import DMARCErrorResults, DMARCResults
 from checkdmarc.utils import (
     HTTPS_REGEX,
@@ -765,8 +771,8 @@ def _query_bimi_record(
     selector: Optional[str] = "default",
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ):
     """
     Queries DNS for a BIMI record
@@ -778,7 +784,7 @@ def _query_bimi_record(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for a record from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         str: A record string or None
@@ -797,7 +803,7 @@ def _query_bimi_record(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         for record in records:
             if record.startswith(txt_prefix):
@@ -852,8 +858,8 @@ def query_bimi_record(
     selector: Optional[str] = "default",
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> BIMIQueryResult:
     """
     Queries DNS for a BIMI record
@@ -865,7 +871,7 @@ def query_bimi_record(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for a record from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         dict: a ``dict`` with the following keys:
@@ -890,7 +896,7 @@ def query_bimi_record(
         nameservers=nameservers,
         resolver=resolver,
         timeout=timeout,
-        timeout_retries=timeout_retries,
+        retries=retries,
     )
     try:
         root_records = query_dns(
@@ -899,7 +905,7 @@ def query_bimi_record(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         for root_record in root_records:
             if root_record.startswith("v=BIMI1"):
@@ -915,7 +921,7 @@ def query_bimi_record(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         location = base_domain
     if record is None:
@@ -1140,8 +1146,8 @@ def check_bimi(
     include_tag_descriptions: bool = False,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> BIMICheckResult:
     """
     Returns a dictionary with a parsed BIMI record or an error.
@@ -1161,7 +1167,7 @@ def check_bimi(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         dict: a ``dict`` with the following keys:
@@ -1186,7 +1192,7 @@ def check_bimi(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         bimi_results["selector"] = selector
         bimi_results["location"] = bimi_query["location"]

--- a/checkdmarc/dmarc.py
+++ b/checkdmarc/dmarc.py
@@ -13,7 +13,11 @@ import dns.exception
 from dns.nameserver import Nameserver
 import pyleri
 
-from checkdmarc._constants import SYNTAX_ERROR_MARKER
+from checkdmarc._constants import (
+    DEFAULT_DNS_TIMEOUT,
+    DEFAULT_DNS_MAX_RETRIES,
+    SYNTAX_ERROR_MARKER,
+)
 from checkdmarc.utils import (
     MAILTO_REGEX,
     WSP_REGEX,
@@ -736,8 +740,8 @@ def _query_dmarc_record(
     *,
     nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
     ignore_unrelated_records: bool = False,
 ) -> Union[str, None]:
     """
@@ -749,7 +753,7 @@ def _query_dmarc_record(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for a record from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
         ignore_unrelated_records (bool): Do not raise a warning if unrelated records are found
 
     Returns:
@@ -769,7 +773,7 @@ def _query_dmarc_record(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         for record in records:
             if record.startswith(txt_prefix):
@@ -808,7 +812,7 @@ def _query_dmarc_record(
                 nameservers=nameservers,
                 resolver=resolver,
                 timeout=timeout,
-                timeout_retries=timeout_retries,
+                retries=retries,
             )
             for record in records:
                 if record.startswith(txt_prefix):
@@ -841,8 +845,8 @@ def query_dmarc_record(
     *,
     nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
     ignore_unrelated_records: bool = False,
 ) -> DMARCRecordQueryResults:
     """
@@ -854,7 +858,7 @@ def query_dmarc_record(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for a record from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
         ignore_unrelated_records (bool): Ignore unrelated TXT records
 
     Returns:
@@ -881,7 +885,7 @@ def query_dmarc_record(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
             ignore_unrelated_records=ignore_unrelated_records,
         )
     except DMARCRecordNotFound:
@@ -897,7 +901,7 @@ def query_dmarc_record(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         for root_record in root_records:
             if root_record.startswith("v=DMARC1"):
@@ -931,7 +935,7 @@ def query_dmarc_record(
                         nameservers=nameservers,
                         resolver=resolver,
                         timeout=timeout,
-                        timeout_retries=timeout_retries,
+                        retries=retries,
                         ignore_unrelated_records=ignore_unrelated_records,
                     )
                     if record is not None:
@@ -1048,8 +1052,8 @@ def check_wildcard_dmarc_report_authorization(
     nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
     ignore_unrelated_records: bool = False,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> bool:
     """
     Checks for a wildcard DMARC report authorization record, e.g.:
@@ -1065,7 +1069,7 @@ def check_wildcard_dmarc_report_authorization(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
 
     Returns:
@@ -1082,7 +1086,7 @@ def check_wildcard_dmarc_report_authorization(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
 
         for record in records:
@@ -1116,8 +1120,8 @@ def verify_dmarc_report_destination(
     nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
     ignore_unrelated_records: bool = False,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> None:
     """
     Checks if the report destination accepts reports for the source domain
@@ -1132,7 +1136,7 @@ def verify_dmarc_report_destination(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                         requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
 
     Raises:
@@ -1150,7 +1154,7 @@ def verify_dmarc_report_destination(
             ignore_unrelated_records=ignore_unrelated_records,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         ):
             return
         target = f"{source_domain}._report._dmarc.{destination_domain}"
@@ -1170,7 +1174,7 @@ def verify_dmarc_report_destination(
                 nameservers=nameservers,
                 resolver=resolver,
                 timeout=timeout,
-                timeout_retries=timeout_retries,
+                retries=retries,
             )
 
             for record in records:
@@ -1205,8 +1209,8 @@ def parse_dmarc_record(
     nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
     ignore_unrelated_records: bool = False,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
     syntax_error_marker: str = SYNTAX_ERROR_MARKER,
 ) -> ParsedDMARCRecord: ...
 
@@ -1221,8 +1225,8 @@ def parse_dmarc_record(
     nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
     ignore_unrelated_records: bool = False,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
     syntax_error_marker: str = SYNTAX_ERROR_MARKER,
 ) -> ParsedDMARCRecordWithDescriptions: ...
 
@@ -1236,8 +1240,8 @@ def parse_dmarc_record(
     nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
     ignore_unrelated_records: bool = False,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
     syntax_error_marker: str = SYNTAX_ERROR_MARKER,
 ) -> Union[ParsedDMARCRecord, ParsedDMARCRecordWithDescriptions]:
     """
@@ -1253,7 +1257,7 @@ def parse_dmarc_record(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
         syntax_error_marker (str): The maker for pointing out syntax errors
 
     Returns:
@@ -1443,7 +1447,7 @@ def parse_dmarc_record(
                         ignore_unrelated_records=ignore_unrelated_records,
                         resolver=resolver,
                         timeout=timeout,
-                        timeout_retries=timeout_retries,
+                        retries=retries,
                     )
                 try:
                     hosts = get_mx_records(
@@ -1451,7 +1455,7 @@ def parse_dmarc_record(
                         nameservers=nameservers,
                         resolver=resolver,
                         timeout=timeout,
-                        timeout_retries=timeout_retries,
+                        retries=retries,
                     )
                     if len(hosts) == 0:
                         raise DMARCReportEmailAddressMissingMXRecords(
@@ -1506,7 +1510,7 @@ def parse_dmarc_record(
                         ignore_unrelated_records=ignore_unrelated_records,
                         resolver=resolver,
                         timeout=timeout,
-                        timeout_retries=timeout_retries,
+                        retries=retries,
                     )
                 try:
                     hosts = get_mx_records(
@@ -1514,7 +1518,7 @@ def parse_dmarc_record(
                         nameservers=nameservers,
                         resolver=resolver,
                         timeout=timeout,
-                        timeout_retries=timeout_retries,
+                        retries=retries,
                     )
                     if len(hosts) == 0:
                         raise DMARCReportEmailAddressMissingMXRecords(
@@ -1580,8 +1584,8 @@ def get_dmarc_record(
     include_tag_descriptions: Literal[False] = False,
     nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> DMARCRecord: ...
 
 
@@ -1592,8 +1596,8 @@ def get_dmarc_record(
     include_tag_descriptions: Literal[True],
     nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> DMARCRecordWithDescriptions: ...
 
 
@@ -1603,8 +1607,8 @@ def get_dmarc_record(
     include_tag_descriptions: bool = False,
     nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> Union[DMARCRecord, DMARCRecordWithDescriptions]:
     """
     Retrieves a DMARC record for a domain and parses it
@@ -1616,7 +1620,7 @@ def get_dmarc_record(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         dict: a ``dict`` with the following keys:
@@ -1650,7 +1654,7 @@ def get_dmarc_record(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         result: DMARCRecordWithDescriptions = {
             "record": query["record"],
@@ -1666,7 +1670,7 @@ def get_dmarc_record(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         result_no_desc: DMARCRecord = {
             "record": query["record"],
@@ -1684,8 +1688,8 @@ def check_dmarc(
     ignore_unrelated_records: bool = False,
     nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> Union[DMARCResults, DMARCErrorResults]:
     """
     Returns a dictionary with a parsed DMARC record or an error
@@ -1699,7 +1703,7 @@ def check_dmarc(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for a record from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
 
     Returns:
@@ -1723,7 +1727,7 @@ def check_dmarc(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
     except DMARCError as error:
         error_results: DMARCErrorResults = {
@@ -1743,7 +1747,7 @@ def check_dmarc(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         combined_warnings = dmarc_query["warnings"] + parsed_dmarc_record["warnings"]
         dmarc_results: DMARCResults = {

--- a/checkdmarc/dnssec.py
+++ b/checkdmarc/dnssec.py
@@ -17,7 +17,12 @@ from dns.nameserver import Nameserver
 from dns.rdatatype import RdataType
 from expiringdict import ExpiringDict
 
-from checkdmarc._constants import DNSSEC_CACHE_MAX_AGE_SECONDS, DNSSEC_CACHE_MAX_LEN
+from checkdmarc._constants import (
+    DEFAULT_DNS_NAMESERVERS,
+    DEFAULT_DNS_TIMEOUT,
+    DNSSEC_CACHE_MAX_AGE_SECONDS,
+    DNSSEC_CACHE_MAX_LEN,
+)
 from checkdmarc.utils import get_base_domain, normalize_domain
 
 """Copyright 2019-2023 Sean Whalen
@@ -49,7 +54,7 @@ def get_dnskey(
     domain: str,
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
-    timeout: float = 2.0,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
     cache: Optional[ExpiringDict] = None,
 ) -> Optional[dict]:
     """
@@ -65,7 +70,7 @@ def get_dnskey(
         A DNSKEY dictionary if a DNSKEY is found
     """
     if nameservers is None:
-        nameservers = dns.resolver.Resolver().nameservers
+        nameservers = list(DEFAULT_DNS_NAMESERVERS)
     if cache is None:
         cache = DNSKEY_CACHE
 
@@ -110,7 +115,7 @@ def test_dnssec(
     domain: str,
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
-    timeout: float = 2.0,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
     cache: Optional[ExpiringDict] = None,
 ) -> bool:
     """
@@ -126,7 +131,7 @@ def test_dnssec(
         bool: DNSSEC status
     """
     if nameservers is None:
-        nameservers = dns.resolver.Resolver().nameservers
+        nameservers = list(DEFAULT_DNS_NAMESERVERS)
     if cache is None:
         cache = DNSSEC_CACHE
 
@@ -176,7 +181,7 @@ def get_tlsa_records(
     hostname: str,
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
-    timeout: float = 2.0,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
     port: int = 25,
     protocol: str = "tcp",
     cache: Optional[ExpiringDict] = None,
@@ -196,7 +201,7 @@ def get_tlsa_records(
         list: A list of TLSA records
     """
     if nameservers is None:
-        nameservers = dns.resolver.Resolver().nameservers
+        nameservers = list(DEFAULT_DNS_NAMESERVERS)
     protocol = protocol.lower()
     if cache is None:
         cache = TLSA_CACHE

--- a/checkdmarc/mta_sts.py
+++ b/checkdmarc/mta_sts.py
@@ -14,7 +14,13 @@ from dns.nameserver import Nameserver
 import requests
 import pyleri
 
-from checkdmarc._constants import DEFAULT_HTTP_TIMEOUT, SYNTAX_ERROR_MARKER, USER_AGENT
+from checkdmarc._constants import (
+    DEFAULT_DNS_TIMEOUT,
+    DEFAULT_DNS_MAX_RETRIES,
+    DEFAULT_HTTP_TIMEOUT,
+    SYNTAX_ERROR_MARKER,
+    USER_AGENT,
+)
 from checkdmarc.utils import WSP_REGEX, normalize_domain, query_dns
 
 """Copyright 2019-2023 Sean Whalen
@@ -207,8 +213,8 @@ def query_mta_sts_record(
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> MTASTSQueryResults:
     """
     Queries DNS for an MTA-STS record
@@ -219,7 +225,7 @@ def query_mta_sts_record(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for a record from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
 
     Returns:
@@ -249,7 +255,7 @@ def query_mta_sts_record(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         for record in records:
             if record.startswith(txt_prefix):
@@ -277,7 +283,7 @@ def query_mta_sts_record(
                 nameservers=nameservers,
                 resolver=resolver,
                 timeout=timeout,
-                timeout_retries=timeout_retries,
+                retries=retries,
             )
             for record in records:
                 if record.startswith(txt_prefix):
@@ -533,8 +539,8 @@ def check_mta_sts(
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> MTASTSCheckResults:
     """
     Returns a dictionary with a parsed MTA-STS policy or an error.
@@ -545,7 +551,7 @@ def check_mta_sts(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
 
     Returns:
@@ -569,7 +575,7 @@ def check_mta_sts(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         warnings = mta_sts_record["warnings"]
         mta_sts_record = parse_mta_sts_record(mta_sts_record["record"])

--- a/checkdmarc/smtp.py
+++ b/checkdmarc/smtp.py
@@ -16,7 +16,13 @@ from dns.nameserver import Nameserver
 
 from expiringdict import ExpiringDict
 
-from checkdmarc._constants import SMTP_CACHE_MAX_AGE_SECONDS, SMTP_CACHE_MAX_LEN
+from checkdmarc._constants import (
+    DEFAULT_DNS_TIMEOUT,
+    DEFAULT_DNS_MAX_RETRIES,
+    DEFAULT_SMTP_TIMEOUT,
+    SMTP_CACHE_MAX_AGE_SECONDS,
+    SMTP_CACHE_MAX_LEN,
+)
 from checkdmarc.dnssec import get_tlsa_records, test_dnssec
 from checkdmarc.mta_sts import mx_in_mta_sts_patterns
 from checkdmarc.utils import (
@@ -73,7 +79,7 @@ def test_tls(
     *,
     ssl_context: Optional[ssl.SSLContext] = None,
     cache: Optional[ExpiringDict] = None,
-    timeout: float = 5,
+    timeout: float = DEFAULT_SMTP_TIMEOUT,
 ) -> bool:
     """
     Attempt to connect to an SMTP server port 465 and validate TLS/SSL support
@@ -185,7 +191,7 @@ def test_starttls(
     *,
     ssl_context: Optional[ssl.SSLContext] = None,
     cache: Optional[ExpiringDict] = None,
-    timeout: float = 5,
+    timeout: float = DEFAULT_SMTP_TIMEOUT,
 ) -> bool:
     """
     Attempt to connect to an SMTP server and validate STARTTLS support
@@ -304,8 +310,8 @@ def get_mx_hosts(
     parked: bool = False,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> MXResultsSuccess:
     """
     Gets MX hostname and their addresses
@@ -343,7 +349,7 @@ def get_mx_hosts(
         nameservers=nameservers,
         resolver=resolver,
         timeout=timeout,
-        timeout_retries=timeout_retries,
+        retries=retries,
     )
     for record in mx_records:
         hosts.append(
@@ -395,7 +401,7 @@ def get_mx_hosts(
                 nameservers=nameservers,
                 resolver=resolver,
                 timeout=timeout,
-                timeout_retries=timeout_retries,
+                retries=retries,
             )
             tlsa_records = get_tlsa_records(
                 hostname,
@@ -424,7 +430,7 @@ def get_mx_hosts(
                     nameservers=nameservers,
                     resolver=resolver,
                     timeout=timeout,
-                    timeout_retries=timeout_retries,
+                    retries=retries,
                 )
             except DNSException:
                 reverse_hostnames = []
@@ -438,7 +444,7 @@ def get_mx_hosts(
                         reverse_hostname,
                         resolver=resolver,
                         timeout=timeout,
-                        timeout_retries=timeout_retries,
+                        retries=retries,
                     )
                 except DNSException as warning:
                     warnings.append(str(warning))
@@ -493,8 +499,8 @@ def check_mx(
     skip_tls: bool = False,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> MXResults:
     """
     Gets MX hostname and their addresses, or an empty list of hosts and an
@@ -509,7 +515,7 @@ def check_mx(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for a record from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         dict: a ``dict`` with the following keys:
@@ -536,7 +542,7 @@ def check_mx(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         return mx_results
     except DNSException as error:

--- a/checkdmarc/smtp_tls_reporting.py
+++ b/checkdmarc/smtp_tls_reporting.py
@@ -14,7 +14,11 @@ import dns.resolver
 from dns.nameserver import Nameserver
 import pyleri
 
-from checkdmarc._constants import SYNTAX_ERROR_MARKER
+from checkdmarc._constants import (
+    DEFAULT_DNS_TIMEOUT,
+    DEFAULT_DNS_MAX_RETRIES,
+    SYNTAX_ERROR_MARKER,
+)
 from checkdmarc.utils import (
     HTTPS_REGEX,
     MAILTO_REGEX_STRING,
@@ -182,8 +186,8 @@ def query_smtp_tls_reporting_record(
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> SMTPTLSReportingQueryResults:
     """
     Queries DNS for an SMTP TLS Reporting record
@@ -194,7 +198,7 @@ def query_smtp_tls_reporting_record(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for a record from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         dict: a ``dict`` with the following keys:
@@ -223,7 +227,7 @@ def query_smtp_tls_reporting_record(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         for record in records:
             if record.startswith(txt_prefix):
@@ -253,7 +257,7 @@ def query_smtp_tls_reporting_record(
                 nameservers=nameservers,
                 resolver=resolver,
                 timeout=timeout,
-                timeout_retries=timeout_retries,
+                retries=retries,
             )
             for record in records:
                 if record.startswith(txt_prefix):
@@ -389,8 +393,8 @@ def check_smtp_tls_reporting(
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> SMTPTLSReportingResults:
     """
     Returns a dictionary with a parsed SMTP-TLS Reporting policy or an error.
@@ -401,7 +405,7 @@ def check_smtp_tls_reporting(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         dict: a ``dict`` with the following keys:
@@ -423,7 +427,7 @@ def check_smtp_tls_reporting(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         warnings = smtp_tls_reporting_record["warnings"]
         smtp_tls_reporting_record = parse_smtp_tls_reporting_record(

--- a/checkdmarc/soa.py
+++ b/checkdmarc/soa.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 import dns.resolver
 from dns.nameserver import Nameserver
 
+from checkdmarc._constants import DEFAULT_DNS_TIMEOUT, DEFAULT_DNS_MAX_RETRIES
 from checkdmarc.utils import get_soa_record
 
 """Functions for parsing DNS Start of Authority records"""
@@ -94,8 +95,8 @@ def check_soa(
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> SOARecordResults:
     """
     Returns a dictionary of a domain's SOA record and a parsed version of the record or a dictionary with an
@@ -107,7 +108,7 @@ def check_soa(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for a record from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
     Returns:
         dict: A dictionary with the following keys:
 
@@ -126,7 +127,7 @@ def check_soa(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
 
     except Exception as e:

--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -15,7 +15,11 @@ import dns.resolver
 from dns.nameserver import Nameserver
 import pyleri
 
-from checkdmarc._constants import SYNTAX_ERROR_MARKER
+from checkdmarc._constants import (
+    DEFAULT_DNS_TIMEOUT,
+    DEFAULT_DNS_MAX_RETRIES,
+    SYNTAX_ERROR_MARKER,
+)
 from checkdmarc.utils import (
     DNSException,
     DNSExceptionNXDOMAIN,
@@ -235,8 +239,8 @@ def ptr_match(
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> bool:
     """
     Preforms a ptr mechanism check.
@@ -259,7 +263,7 @@ def ptr_match(
         nameservers=nameservers,
         resolver=resolver,
         timeout=timeout,
-        timeout_retries=timeout_retries,
+        retries=retries,
     )
     for name in hostnames:
         if not name.endswith(domain):
@@ -269,7 +273,7 @@ def ptr_match(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         if ip_address in ips:
             return True
@@ -376,8 +380,8 @@ def query_spf_record(
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     quoted_txt_segments: bool = False,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> SPFQueryResults:
     """
     Queries DNS for an SPF record
@@ -388,7 +392,7 @@ def query_spf_record(
         nameservers (list): A list of nameservers to query
         resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         dict: A ``dict`` with the following keys:
@@ -412,7 +416,7 @@ def query_spf_record(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
     except (dns.resolver.NoAnswer, Exception):
         pass
@@ -433,7 +437,7 @@ def query_spf_record(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         spf_record = None
         for record in answers:
@@ -529,8 +533,8 @@ def parse_spf_record(
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
     recursion: Optional[list[str]] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
     syntax_error_marker: str = SYNTAX_ERROR_MARKER,
 ) -> SPFRecordResults:
     """
@@ -546,7 +550,7 @@ def parse_spf_record(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
         recursion (list): A list of domains used in recursion
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
         syntax_error_marker (str): The maker for pointing out syntax errors
 
     Returns:
@@ -668,7 +672,7 @@ def parse_spf_record(
                         exp,
                         nameservers=nameservers,
                         timeout=timeout,
-                        timeout_retries=timeout_retries,
+                        retries=retries,
                     )
                     if len(exp_txt_records) == 0:
                         warnings.append(f"No TXT records at exp value {exp}.")
@@ -759,7 +763,7 @@ def parse_spf_record(
                     nameservers=nameservers,
                     resolver=resolver,
                     timeout=timeout,
-                    timeout_retries=timeout_retries,
+                    retries=retries,
                 )
                 if len(a_records) == 0:
                     # Do not pre-increment void counters here; let the outer
@@ -806,7 +810,7 @@ def parse_spf_record(
                     nameservers=nameservers,
                     resolver=resolver,
                     timeout=timeout,
-                    timeout_retries=timeout_retries,
+                    retries=retries,
                 )
 
                 if len(mx_hosts) == 0:
@@ -833,7 +837,7 @@ def parse_spf_record(
                             nameservers=nameservers,
                             resolver=resolver,
                             timeout=timeout,
-                            timeout_retries=timeout_retries,
+                            retries=retries,
                         )
                         mx_host_addresses[hostname] = _addresses
 
@@ -925,7 +929,7 @@ def parse_spf_record(
                         nameservers=nameservers,
                         resolver=resolver,
                         timeout=timeout,
-                        timeout_retries=timeout_retries,
+                        retries=retries,
                     )
                     redirect_record = redirect_record["record"]
                     redirected_spf = parse_spf_record(
@@ -936,7 +940,7 @@ def parse_spf_record(
                         nameservers=nameservers,
                         resolver=resolver,
                         timeout=timeout,
-                        timeout_retries=timeout_retries,
+                        retries=retries,
                     )
                     parsed["all"] = redirected_spf["parsed"]["all"]
                     mechanism_dns_lookups += redirected_spf["dns_lookups"]
@@ -994,7 +998,7 @@ def parse_spf_record(
                             exp,
                             nameservers=nameservers,
                             timeout=timeout,
-                            timeout_retries=timeout_retries,
+                            retries=retries,
                         )
                         if len(exp_txt_records) == 0:
                             warnings.append(f"No TXT records at exp value {exp}.")
@@ -1036,7 +1040,7 @@ def parse_spf_record(
                         nameservers=nameservers,
                         resolver=resolver,
                         timeout=timeout,
-                        timeout_retries=timeout_retries,
+                        retries=retries,
                     )
                     include_record = include_record["record"]
                     include = parse_spf_record(
@@ -1047,7 +1051,7 @@ def parse_spf_record(
                         nameservers=nameservers,
                         resolver=resolver,
                         timeout=timeout,
-                        timeout_retries=timeout_retries,
+                        retries=retries,
                     )
                     total_dns_lookups += include["dns_lookups"]
                     total_void_dns_lookups += include["void_dns_lookups"]
@@ -1126,7 +1130,7 @@ def parse_spf_record(
                     nameservers=nameservers,
                     resolver=resolver,
                     timeout=timeout,
-                    timeout_retries=timeout_retries,
+                    retries=retries,
                 )
                 if len(a_records) == 0:
                     # Do not pre-increment void counters here; let the outer
@@ -1217,8 +1221,8 @@ def get_spf_record(
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> SPFRecordResults:
     """
     Retrieves and parses an SPF record
@@ -1228,7 +1232,7 @@ def get_spf_record(
         nameservers (list): A list of nameservers to query
         resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
         timeout (float): Number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         dict: An SPF record parsed by result
@@ -1246,7 +1250,7 @@ def get_spf_record(
         nameservers=nameservers,
         resolver=resolver,
         timeout=timeout,
-        timeout_retries=timeout_retries,
+        retries=retries,
     )
     record = query_result["record"]
     query_warnings = query_result.get("warnings", [])
@@ -1257,7 +1261,7 @@ def get_spf_record(
         nameservers=nameservers,
         resolver=resolver,
         timeout=timeout,
-        timeout_retries=timeout_retries,
+        retries=retries,
     )
     parsed_record["record"] = record
 
@@ -1274,8 +1278,8 @@ def check_spf(
     parked: bool = False,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> dict:
     """
     Returns a dictionary with a parsed SPF record or an error.
@@ -1286,7 +1290,7 @@ def check_spf(
         nameservers (list): A list of nameservers to query
         resolver (dns.resolver.Resolver): A resolver object to use for DNS requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         dict: A ``dict`` with the following keys:
@@ -1315,7 +1319,7 @@ def check_spf(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         spf_results["record"] = spf_query["record"]
         spf_results["warnings"] = spf_query["warnings"]
@@ -1328,7 +1332,7 @@ def check_spf(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
 
         spf_results["dns_lookups"] = parsed_spf["dns_lookups"]

--- a/checkdmarc/utils.py
+++ b/checkdmarc/utils.py
@@ -16,7 +16,13 @@ from dns.nameserver import Nameserver
 import publicsuffixlist
 from expiringdict import ExpiringDict
 
-from checkdmarc._constants import DNS_CACHE_MAX_LEN, DNSSEC_CACHE_MAX_AGE_SECONDS
+from checkdmarc._constants import (
+    DEFAULT_DNS_MAX_RETRIES,
+    DEFAULT_DNS_NAMESERVERS,
+    DEFAULT_DNS_TIMEOUT,
+    DNS_CACHE_MAX_LEN,
+    DNSSEC_CACHE_MAX_AGE_SECONDS,
+)
 
 """Copyright 2019-2023 Sean Whalen
 
@@ -34,6 +40,15 @@ limitations under the License."""
 
 DNS_CACHE = ExpiringDict(
     max_len=DNS_CACHE_MAX_LEN, max_age_seconds=DNSSEC_CACHE_MAX_AGE_SECONDS
+)
+
+# Errors considered transient and retryable by query_dns. LifetimeTimeout is
+# dnspython's deadline expiry; NoNameservers typically wraps a SERVFAIL from
+# upstream; OSError covers socket-level failures during TCP fallback.
+_RETRYABLE_DNS_ERRORS = (
+    dns.resolver.LifetimeTimeout,
+    dns.resolver.NoNameservers,
+    OSError,
 )
 
 WSP_REGEX = r"[ \t]"
@@ -125,8 +140,8 @@ def query_dns(
     quoted_txt_segments: bool = False,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
     _attempt: int = 0,
     cache: Optional[ExpiringDict] = None,
 ) -> list[str]:
@@ -137,11 +152,21 @@ def query_dns(
         domain (str): The domain or subdomain to query about
         record_type (str): The record type to query for
         quoted_txt_segments (bool): Preserve quotes in TXT records
-        nameservers (list): A list of one or more nameservers to use
+        nameservers (list): A list of one or more nameservers to use.
+                            Defaults to ``DEFAULT_DNS_NAMESERVERS`` (a mix of
+                            Cloudflare and Google public resolvers) so that
+                            failover happens out of the box when one
+                            provider's path is slow or broken.
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
-        timeout (float): Sets the DNS timeout in seconds
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        timeout (float): Overall DNS lifetime budget in seconds per
+                         configured nameserver; per-nameserver queries are
+                         capped at ``min(1.0, timeout)`` so a slow or broken
+                         nameserver falls through to the next quickly
+        retries (int): Number of times to retry the whole query after a
+                       timeout or other transient error (``LifetimeTimeout``,
+                       ``NoNameservers``, ``OSError``). Failover between
+                       configured nameservers happens within each attempt.
         cache (ExpiringDict): Cache storage
 
     Returns:
@@ -159,16 +184,21 @@ def query_dns(
     if not resolver:
         resolver = dns.resolver.Resolver()
         timeout = float(timeout)
-        if nameservers is not None:
-            resolver.nameservers = nameservers
-        resolver.timeout = timeout
-        resolver.lifetime = timeout
+        if nameservers is None:
+            nameservers = DEFAULT_DNS_NAMESERVERS
+        resolver.nameservers = list(nameservers)
+        # Cap the per-nameserver query at 1s so a slow or broken nameserver
+        # falls through to the next one quickly instead of hanging. The
+        # `timeout` argument governs the overall lifetime budget for the
+        # whole resolve() call across all configured nameservers.
+        resolver.timeout = min(1.0, timeout)
+        resolver.lifetime = timeout * max(len(resolver.nameservers), 1)
     if record_type == "TXT":
         try:
-            answers = resolver.resolve(domain, record_type, lifetime=timeout)
-        except dns.resolver.LifetimeTimeout as e:
+            answers = resolver.resolve(domain, record_type, lifetime=resolver.lifetime)
+        except _RETRYABLE_DNS_ERRORS as e:
             _attempt += 1
-            if _attempt > timeout_retries:
+            if _attempt > retries:
                 raise e
             return query_dns(
                 domain,
@@ -176,7 +206,7 @@ def query_dns(
                 nameservers=nameservers,
                 resolver=resolver,
                 timeout=timeout,
-                timeout_retries=timeout_retries,
+                retries=retries,
                 _attempt=_attempt,
             )
         resource_records = list(
@@ -208,10 +238,10 @@ def query_dns(
             records.append(r)
     else:
         try:
-            answers = resolver.resolve(domain, record_type, lifetime=timeout)
-        except dns.resolver.LifetimeTimeout as e:
+            answers = resolver.resolve(domain, record_type, lifetime=resolver.lifetime)
+        except _RETRYABLE_DNS_ERRORS as e:
             _attempt += 1
-            if _attempt > timeout_retries:
+            if _attempt > retries:
                 raise e
             return query_dns(
                 domain,
@@ -219,7 +249,7 @@ def query_dns(
                 nameservers=nameservers,
                 resolver=resolver,
                 timeout=timeout,
-                timeout_retries=timeout_retries,
+                retries=retries,
                 _attempt=_attempt,
             )
         records = list(
@@ -239,8 +269,8 @@ def get_a_records(
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> list[str]:
     """
     Queries DNS for A and AAAA records
@@ -269,7 +299,7 @@ def get_a_records(
                 nameservers=nameservers,
                 resolver=resolver,
                 timeout=timeout,
-                timeout_retries=timeout_retries,
+                retries=retries,
             )
         except dns.resolver.NXDOMAIN:
             raise DNSExceptionNXDOMAIN("The domain does not exist.")
@@ -288,8 +318,8 @@ def get_reverse_dns(
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> list[str]:
     """
     Queries for an IP addresses reverse DNS hostname(s)
@@ -300,7 +330,7 @@ def get_reverse_dns(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         list: A list of reverse DNS hostnames
@@ -318,7 +348,7 @@ def get_reverse_dns(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
     except dns.resolver.NXDOMAIN:
         return []
@@ -334,8 +364,8 @@ def get_txt_records(
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     quoted_txt_segments: bool = False,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> list[str]:
     """
     Queries DNS for TXT records
@@ -347,7 +377,7 @@ def get_txt_records(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         list: A list of TXT records
@@ -364,7 +394,7 @@ def get_txt_records(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
     except dns.resolver.NXDOMAIN:
         raise DNSExceptionNXDOMAIN("The domain does not exist.")
@@ -381,8 +411,8 @@ def get_soa_record(
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> str:
     """
     Queries DNS for an SOA record
@@ -393,7 +423,7 @@ def get_soa_record(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         str: An SOA record
@@ -410,7 +440,7 @@ def get_soa_record(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )[0]
     except dns.resolver.NXDOMAIN:
         raise DNSExceptionNXDOMAIN("The domain does not exist.")
@@ -428,8 +458,8 @@ def get_nameservers(
     approved_nameservers: Optional[Sequence[str | Nameserver]] = None,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> NameserverResultOk:
     """
     Gets a list of nameservers for a given domain
@@ -441,7 +471,7 @@ def get_nameservers(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for a record from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         dict: A dictionary with the following keys:
@@ -459,7 +489,7 @@ def get_nameservers(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
     except dns.resolver.NXDOMAIN:
         raise DNSExceptionNXDOMAIN("The domain does not exist.")
@@ -489,8 +519,8 @@ def get_mx_records(
     *,
     nameservers: Optional[Sequence[str | Nameserver]] = None,
     resolver: Optional[dns.resolver.Resolver] = None,
-    timeout: float = 2.0,
-    timeout_retries: int = 2,
+    timeout: float = DEFAULT_DNS_TIMEOUT,
+    retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> list[MXHost]:
     """
     Queries DNS for a list of Mail Exchange hosts
@@ -501,7 +531,7 @@ def get_mx_records(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): number of seconds to wait for an answer from DNS
-        timeout_retries (int): The number of times to reattempt a query after a timeout
+        retries (int): The number of times to retry on timeout or other transient errors
 
     Returns:
         list: A list of ``dicts``; each containing a ``preference``
@@ -520,7 +550,7 @@ def get_mx_records(
             nameservers=nameservers,
             resolver=resolver,
             timeout=timeout,
-            timeout_retries=timeout_retries,
+            retries=retries,
         )
         if answers == ["0 "]:
             logging.debug('"No Service" MX record found')


### PR DESCRIPTION
## Summary

- Rename `timeout_retries` kwarg → `retries` (CLI `--timeout-retries` → `--retries`). Retry scope now covers `LifetimeTimeout`, `NoNameservers` (SERVFAIL), and `OSError` during TCP fallback. `NXDOMAIN` / `NoAnswer` remain non-retryable.
- Default retries drop from 2 → 0. The old behavior tripled worst-case query time when authoritative servers stalled without helping recover.
- Default to mixed-provider nameservers (`1.1.1.1`, `8.8.8.8`) when callers don't pass `nameservers`, so cross-provider failover works out of the box. Callers that need system or internal resolvers must pass them explicitly.
- Cap per-nameserver query at `min(1.0, timeout)` so a slow or broken nameserver falls through in ~1s instead of consuming the whole lifetime.
- Centralize DNS/SMTP defaults in `checkdmarc._constants`: `DEFAULT_DNS_TIMEOUT`, `DEFAULT_DNS_MAX_RETRIES`, `DEFAULT_DNS_NAMESERVERS`, `DEFAULT_SMTP_TIMEOUT`.

Breaking: `timeout_retries` kwarg and `--timeout-retries` CLI flag are gone. Hence the minor bump to 5.15.0.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check .` — clean
- [x] `GITHUB_ACTIONS=1 python3 -m pytest tests.py` — 154 passed, 1 skipped
- [x] Spot-check: `query_dns` succeeds with the default nameserver list (no args)
- [ ] CI passes on PR
- [ ] Tag `5.15.0` after merge, then build/publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)