### PR TITLE
Restore system-resolver default, recommend public resolvers (5.15.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 5.15.1
+
+### Changes
+
+- Revert the 5.15.0 default of auto-configuring public nameservers
+  (`1.1.1.1`, `8.8.8.8`) when no `nameservers` are passed. When `nameservers`
+  is `None`, `checkdmarc` now falls back to the system-configured resolvers
+  again (`/etc/resolv.conf` on Linux/macOS, the OS resolver on Windows),
+  matching the 5.14.x and earlier behavior. The auto-configured default would
+  surprise users running split-horizon or internal DNS and broke workflows
+  that previously relied on the system resolver.
+- Rename the exposed constant from `DEFAULT_DNS_NAMESERVERS` to
+  `RECOMMENDED_DNS_NAMESERVERS` to reflect that it is an opt-in
+  recommendation, not an automatic default. It is re-exported from the
+  package root as `checkdmarc.RECOMMENDED_DNS_NAMESERVERS` so callers can
+  easily opt in with
+  `check_domains(..., nameservers=RECOMMENDED_DNS_NAMESERVERS)`.
+- Documentation now calls out mixing public resolvers from different
+  providers as a best practice for public-internet checks.
+
 ## 5.15.0
 
 ### Changes (breaking)

--- a/checkdmarc/__init__.py
+++ b/checkdmarc/__init__.py
@@ -16,7 +16,11 @@ import dns.resolver
 from dns.nameserver import Nameserver
 
 import checkdmarc._constants
-from checkdmarc._constants import DEFAULT_DNS_TIMEOUT, DEFAULT_DNS_MAX_RETRIES
+from checkdmarc._constants import (
+    DEFAULT_DNS_MAX_RETRIES,
+    DEFAULT_DNS_TIMEOUT,
+    RECOMMENDED_DNS_NAMESERVERS as RECOMMENDED_DNS_NAMESERVERS,
+)
 from checkdmarc.bimi import check_bimi, BIMICheckResult
 from checkdmarc.dmarc import check_dmarc, DMARCResults, DMARCErrorResults
 from checkdmarc.dnssec import test_dnssec

--- a/checkdmarc/_cli.py
+++ b/checkdmarc/_cli.py
@@ -11,8 +11,8 @@ import logging
 
 from checkdmarc._constants import (
     DEFAULT_DNS_MAX_RETRIES,
-    DEFAULT_DNS_NAMESERVERS,
     DEFAULT_DNS_TIMEOUT,
+    RECOMMENDED_DNS_NAMESERVERS,
 )
 from checkdmarc import (
     __version__,
@@ -79,7 +79,11 @@ def _main():
         "-n",
         "--nameserver",
         nargs="+",
-        help=(f"nameservers to query (default: {' '.join(DEFAULT_DNS_NAMESERVERS)})"),
+        help=(
+            "nameservers to query (default: the system-configured resolvers). "
+            "For reliability, passing a mix of public resolvers is recommended, "
+            f"e.g. {' '.join(RECOMMENDED_DNS_NAMESERVERS)}"
+        ),
     )
     arg_parser.add_argument(
         "-t",

--- a/checkdmarc/_constants.py
+++ b/checkdmarc/_constants.py
@@ -19,7 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-__version__ = "5.15.0"
+__version__ = "5.15.1"
 
 OS = platform.system()
 OS_RELEASE = platform.release()
@@ -28,10 +28,13 @@ SYNTAX_ERROR_MARKER = "➞"
 DEFAULT_HTTP_TIMEOUT = 2.0
 DEFAULT_DNS_TIMEOUT = 2.0
 DEFAULT_DNS_MAX_RETRIES = 0
-# Mix providers so a single operator's anycast outage or authoritative-server
-# incompatibility (e.g. Cloudflare's QNAME minimization vs. certain auth
-# servers) falls through to a different provider within one resolve() call.
-DEFAULT_DNS_NAMESERVERS = ("1.1.1.1", "8.8.8.8")
+# Recommended mix of public resolvers. Not applied automatically — callers
+# opt in by passing ``nameservers=RECOMMENDED_DNS_NAMESERVERS`` (or the CLI
+# equivalent). Mixing providers means a single operator's anycast outage or
+# authoritative-server incompatibility (e.g. Cloudflare's QNAME minimization
+# vs. certain auth servers) falls through to a different provider within one
+# resolve() call.
+RECOMMENDED_DNS_NAMESERVERS = ("1.1.1.1", "8.8.8.8")
 DEFAULT_SMTP_TIMEOUT = 5.0
 CACHE_MAX_LEN = 200000
 CACHE_MAX_AGE_SECONDS = 1800

--- a/checkdmarc/dnssec.py
+++ b/checkdmarc/dnssec.py
@@ -18,7 +18,6 @@ from dns.rdatatype import RdataType
 from expiringdict import ExpiringDict
 
 from checkdmarc._constants import (
-    DEFAULT_DNS_NAMESERVERS,
     DEFAULT_DNS_TIMEOUT,
     DNSSEC_CACHE_MAX_AGE_SECONDS,
     DNSSEC_CACHE_MAX_LEN,
@@ -70,7 +69,7 @@ def get_dnskey(
         A DNSKEY dictionary if a DNSKEY is found
     """
     if nameservers is None:
-        nameservers = list(DEFAULT_DNS_NAMESERVERS)
+        nameservers = dns.resolver.Resolver().nameservers
     if cache is None:
         cache = DNSKEY_CACHE
 
@@ -131,7 +130,7 @@ def test_dnssec(
         bool: DNSSEC status
     """
     if nameservers is None:
-        nameservers = list(DEFAULT_DNS_NAMESERVERS)
+        nameservers = dns.resolver.Resolver().nameservers
     if cache is None:
         cache = DNSSEC_CACHE
 
@@ -201,7 +200,7 @@ def get_tlsa_records(
         list: A list of TLSA records
     """
     if nameservers is None:
-        nameservers = list(DEFAULT_DNS_NAMESERVERS)
+        nameservers = dns.resolver.Resolver().nameservers
     protocol = protocol.lower()
     if cache is None:
         cache = TLSA_CACHE

--- a/checkdmarc/utils.py
+++ b/checkdmarc/utils.py
@@ -18,7 +18,6 @@ from expiringdict import ExpiringDict
 
 from checkdmarc._constants import (
     DEFAULT_DNS_MAX_RETRIES,
-    DEFAULT_DNS_NAMESERVERS,
     DEFAULT_DNS_TIMEOUT,
     DNS_CACHE_MAX_LEN,
     DNSSEC_CACHE_MAX_AGE_SECONDS,
@@ -153,16 +152,19 @@ def query_dns(
         record_type (str): The record type to query for
         quoted_txt_segments (bool): Preserve quotes in TXT records
         nameservers (list): A list of one or more nameservers to use.
-                            Defaults to ``DEFAULT_DNS_NAMESERVERS`` (a mix of
-                            Cloudflare and Google public resolvers) so that
-                            failover happens out of the box when one
+                            Defaults to the system-configured resolvers
+                            (``/etc/resolv.conf`` on Linux/macOS, the OS
+                            resolver on Windows). For reliability, pass
+                            ``RECOMMENDED_DNS_NAMESERVERS`` or your own mix
+                            of public resolvers so failover happens when one
                             provider's path is slow or broken.
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): Overall DNS lifetime budget in seconds per
-                         configured nameserver; per-nameserver queries are
-                         capped at ``min(1.0, timeout)`` so a slow or broken
-                         nameserver falls through to the next quickly
+                         configured nameserver; when more than one
+                         nameserver is configured, per-nameserver queries
+                         are capped at ``min(1.0, timeout)`` so a slow or
+                         broken nameserver falls through to the next quickly
         retries (int): Number of times to retry the whole query after a
                        timeout or other transient error (``LifetimeTimeout``,
                        ``NoNameservers``, ``OSError``). Failover between
@@ -184,15 +186,18 @@ def query_dns(
     if not resolver:
         resolver = dns.resolver.Resolver()
         timeout = float(timeout)
-        if nameservers is None:
-            nameservers = DEFAULT_DNS_NAMESERVERS
-        resolver.nameservers = list(nameservers)
-        # Cap the per-nameserver query at 1s so a slow or broken nameserver
-        # falls through to the next one quickly instead of hanging. The
-        # `timeout` argument governs the overall lifetime budget for the
-        # whole resolve() call across all configured nameservers.
-        resolver.timeout = min(1.0, timeout)
-        resolver.lifetime = timeout * max(len(resolver.nameservers), 1)
+        if nameservers is not None:
+            resolver.nameservers = list(nameservers)
+        # When multiple nameservers are configured, cap the per-nameserver
+        # query at 1s so a slow or broken one falls through to the next
+        # quickly. With a single nameserver (or the system default list),
+        # keep the per-query timeout equal to the overall budget.
+        if len(resolver.nameservers) > 1:
+            resolver.timeout = min(1.0, timeout)
+            resolver.lifetime = timeout * len(resolver.nameservers)
+        else:
+            resolver.timeout = timeout
+            resolver.lifetime = timeout
     if record_type == "TXT":
         try:
             answers = resolver.resolve(domain, record_type, lifetime=resolver.lifetime)

--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -24,7 +24,9 @@ options:
                         one or more file paths to output to (must end in .json or .csv)
                         (silences screen output)
   -n NAMESERVER [NAMESERVER ...], --nameserver NAMESERVER [NAMESERVER ...]
-                        nameservers to query
+                        nameservers to query (default: the system-configured
+                        resolvers). For reliability, passing a mix of public
+                        resolvers is recommended, e.g. 1.1.1.1 8.8.8.8
   -t TIMEOUT, --timeout TIMEOUT
                         number of seconds to wait for an answer from DNS (default 2.0)
   -b BIMI_SELECTOR, --bimi-selector BIMI_SELECTOR
@@ -34,6 +36,42 @@ options:
   --skip-tls            skip TLS/SSL testing
   --debug               enable debugging output
 ```
+
+## Best practice: DNS resolvers
+
+By default, `checkdmarc` queries the nameservers your operating system is
+configured to use (`/etc/resolv.conf` on Linux/macOS, the OS resolver on
+Windows). That keeps behavior predictable for environments that rely on
+split-horizon or internal DNS.
+
+For public-internet checks, **passing a mix of public resolvers from
+different providers is recommended**. It gives you cross-provider failover
+out of the box — if one provider's anycast path is slow or its resolver is
+incompatible with a given authoritative server (e.g. Cloudflare's QNAME
+minimization with certain auth servers), the query falls through to the
+next provider within ~1 second instead of timing out.
+
+On the CLI:
+
+```bash
+checkdmarc -n 1.1.1.1 8.8.8.8 --skip-tls proton.me
+```
+
+In the API, the recommended pair is exposed as
+`checkdmarc.RECOMMENDED_DNS_NAMESERVERS`:
+
+```python
+from checkdmarc import check_domains, RECOMMENDED_DNS_NAMESERVERS
+
+results = check_domains(
+    ["proton.me"],
+    nameservers=RECOMMENDED_DNS_NAMESERVERS,
+)
+```
+
+Pick providers that make sense for your threat model and jurisdiction;
+Cloudflare (`1.1.1.1`), Google (`8.8.8.8`), and Quad9 (`9.9.9.9`) are all
+reasonable starting points.
 
 ## Example
 


### PR DESCRIPTION
## Summary

- Revert the 5.15.0 change that auto-configured `1.1.1.1` and `8.8.8.8` when no `nameservers` were passed. When `nameservers` is `None`, checkdmarc now falls back to the system-configured resolvers again (`/etc/resolv.conf` on Linux/macOS, the OS resolver on Windows), matching 5.14.x and earlier behavior. The auto-configured default surprised users running split-horizon or internal DNS and broke workflows that relied on the system resolver.
- Rename the exposed constant from `DEFAULT_DNS_NAMESERVERS` to `RECOMMENDED_DNS_NAMESERVERS` and re-export it from the package root so callers can opt in with `check_domains(..., nameservers=RECOMMENDED_DNS_NAMESERVERS)`.
- Docs now call out mixing public resolvers from different providers as a best practice for public-internet checks, with CLI and API examples in `docs/source/cli.md`.

## Test plan

- [x] `ruff check` passes
- [x] `ruff format .` clean (no changes)
- [x] `coverage run tests.py` — 155 tests pass (1 skipped)
- [x] Manual smoke: `query_dns` succeeds with system resolver and with `RECOMMENDED_DNS_NAMESERVERS`
- [x] Manual smoke: `test_dnssec('proton.me')` returns `True` using system resolvers

🤖 Generated with [Claude Code](https://claude.com/claude-code)