### PR TITLE
Cap per-query UDP timeout for single-nameserver configs (5.15.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 5.15.2
+
+### Changes
+
+- Cap the per-query UDP timeout at `min(1.0, timeout)` for single-nameserver
+  configurations as well as multi-nameserver ones. Previously, when only one
+  nameserver was configured (or the system default list had a single entry),
+  `resolver.timeout` and `resolver.lifetime` were both set to the full
+  `timeout` budget, which collapses dnspython's UDP retry loop to a single
+  attempt — a single dropped UDP datagram then consumed the whole lifetime
+  and raised `LifetimeTimeout`, while `dig` (which defaults to `+tries=3`)
+  would mask the same blip by retrying. dnspython now retries UDP within
+  the lifetime window (~2 attempts at the default 2s budget), matching
+  `dig`'s behavior in spirit and eliminating spurious single-NS timeouts
+  on paths with occasional packet loss.
+
 ## 5.15.1
 
 ### Changes

--- a/checkdmarc/_constants.py
+++ b/checkdmarc/_constants.py
@@ -19,7 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-__version__ = "5.15.1"
+__version__ = "5.15.2"
 
 OS = platform.system()
 OS_RELEASE = platform.release()

--- a/checkdmarc/utils.py
+++ b/checkdmarc/utils.py
@@ -161,10 +161,13 @@ def query_dns(
         resolver (dns.resolver.Resolver): A resolver object to use for DNS
                                           requests
         timeout (float): Overall DNS lifetime budget in seconds per
-                         configured nameserver; when more than one
-                         nameserver is configured, per-nameserver queries
-                         are capped at ``min(1.0, timeout)`` so a slow or
-                         broken nameserver falls through to the next quickly
+                         configured nameserver. Per-query UDP attempts are
+                         capped at ``min(1.0, timeout)`` so dnspython retries
+                         within the lifetime on transient UDP packet loss
+                         (mirroring ``dig``'s default ``+tries=3`` behavior);
+                         with multiple nameservers configured this same cap
+                         also makes a slow or broken nameserver fall through
+                         to the next quickly
         retries (int): Number of times to retry the whole query after a
                        timeout or other transient error (``LifetimeTimeout``,
                        ``NoNameservers``, ``OSError``). Failover between
@@ -188,15 +191,16 @@ def query_dns(
         timeout = float(timeout)
         if nameservers is not None:
             resolver.nameservers = list(nameservers)
-        # When multiple nameservers are configured, cap the per-nameserver
-        # query at 1s so a slow or broken one falls through to the next
-        # quickly. With a single nameserver (or the system default list),
-        # keep the per-query timeout equal to the overall budget.
+        # Cap per-query UDP timeout at 1s so dnspython retries within the
+        # lifetime window on transient packet loss — otherwise with a single
+        # nameserver and timeout == lifetime, one dropped UDP datagram
+        # consumes the whole budget and raises LifetimeTimeout without a
+        # retry (dig's default +tries=3 masks this case). With multiple
+        # nameservers the same cap lets a slow/broken one fall through.
+        resolver.timeout = min(1.0, timeout)
         if len(resolver.nameservers) > 1:
-            resolver.timeout = min(1.0, timeout)
             resolver.lifetime = timeout * len(resolver.nameservers)
         else:
-            resolver.timeout = timeout
             resolver.lifetime = timeout
     if record_type == "TXT":
         try:


### PR DESCRIPTION
## Summary

- Apply the existing `min(1.0, timeout)` per-query UDP cap to single-nameserver configurations, not just multi-nameserver ones. Before this change, a single configured nameserver produced `resolver.timeout == resolver.lifetime == timeout`, which collapses dnspython's UDP retry loop to one attempt — a single dropped datagram then consumed the whole lifetime and raised `LifetimeTimeout`, while `dig` (defaulting to `+tries=3`) masked the same blip. dnspython now gets ~2 UDP attempts within the default 2s budget.
- No public API change, no new config knob. `DEFAULT_DNS_MAX_RETRIES` stays at 0 — this is a UDP-level retry (same layer as dig's `+tries`), distinct from the app-layer whole-query retry controlled by `retries=`.
- Patch bump to 5.15.2 with matching CHANGELOG entry.

## Test plan

- [x] `ruff check` and `ruff format --check` clean
- [x] Existing test suite passes (`GITHUB_ACTIONS=1 python -m unittest tests.py` — 155 tests, 1 skipped, 0 failures)
- [x] Blackhole-port probe confirms 2 UDP attempts within a 2s lifetime with the new logic (was 1 before)
- [x] Smoke-tested `check_domains(['clera.net'], nameservers=['1.1.1.1'], timeout=2.0)` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)