### PR TITLE
Fix BIMI jurisdiction-field validation; warn on placeholder SVG titles (5.15.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 5.15.4
+
+### Fixes
+
+- Stop reporting `jurisdictionOfIncorporationStateOrProvinceName` /
+  `jurisdictionOfIncorporationLocalityName` as required when both are absent.
+  Per VMC Requirements §7.1.4.2.2(j), entities incorporated at the country
+  level (e.g. `bbc.co.uk`) MUST include only `jurisdictionCountryName` —
+  state/province and locality MUST NOT be present. The same correction
+  applies to the parallel `statute*` fields for Government Marks
+  (§7.1.4.2.2(s)). The locality-level form is still validated:
+  `jurisdictionOfIncorporationLocalityName` (and `statuteLocalityName`)
+  now imply that their state/province counterpart must also be present
+  (#242).
+- Deduplicate the bidirectional "either A or B" error so the
+  `localityName` / `stateOrProvinceName` rule is reported once instead
+  of twice when both fields are absent.
+
+### Changes
+
+- Warn when a BIMI SVG `<title>` element is a generator/template
+  placeholder (e.g. `bimi-svg-tiny-12-ps`, `Untitled`). The title should
+  be a descriptive name for the brand or mark.
+- Document that BIMI mark certificates are validated against the
+  AuthIndicators Working Group's
+  [Minimum Security Requirements for Issuance of Mark Certificates](https://bimigroup.org/resources/VMC_Requirements_latest.pdf).
+
 ## 5.15.3
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please consider [sponsoring my work](https://github.com/sponsors/seanthegeek) if
   - Shows warnings when the DMARC record is made ineffective by `pct` or `sp` values
   - Checks for authorization records on reporting email addresses
 - BIMI
-  - Validation of the mark format and certificate
+  - Validation of the mark format and certificate against the [Minimum Security Requirements for Issuance of Mark Certificates](https://bimigroup.org/resources/VMC_Requirements_latest.pdf)
   - Parsing of the mark certificate
 - MX records
   - Preference

--- a/checkdmarc/_constants.py
+++ b/checkdmarc/_constants.py
@@ -19,7 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-__version__ = "5.15.3"
+__version__ = "5.15.4"
 
 OS = platform.system()
 OS_RELEASE = platform.release()

--- a/checkdmarc/bimi.py
+++ b/checkdmarc/bimi.py
@@ -155,6 +155,14 @@ BIMI_TAG_VALUE_REGEX_STRING = (
 )
 BIMI_TAG_VALUE_REGEX = re.compile(BIMI_TAG_VALUE_REGEX_STRING, re.IGNORECASE)
 
+# Heuristic for SVG <title> elements that look like generator/template
+# placeholders rather than a brand-descriptive title (e.g. the SVG Tiny PS
+# profile name leaked into the title, or a literal "untitled").
+GENERIC_SVG_TITLE_REGEX = re.compile(
+    r"^\s*(bimi[\s\-_]*svg[\s\-_]*tiny[\w\s\-_]*|untitled|title|no\s+title|svg)\s*$",
+    re.IGNORECASE,
+)
+
 # VMC OIDs
 OID_LOGOTYPE = ObjectIdentifier("1.3.6.1.5.5.7.1.12")
 OID_MARK_TYPE = ObjectIdentifier("1.3.6.1.4.1.53087.1.13")
@@ -278,16 +286,27 @@ OPTIONAL_SUBJECT_FIELDS_BY_MARK_TYPE = {
 }
 
 
-FIELD_REQUIRED_IF_FIELD_IS_MISSING = {
+# Pairs where at least one of the two subject fields must be present.
+# Per VMC Requirements §7.1.4.2.2(d, e): localityName is required if
+# stateOrProvinceName is absent (and vice versa).
+EITHER_OR_SUBJECT_FIELDS_BY_MARK_TYPE: dict[str, list[tuple[str, str]]] = {
+    "All": [
+        ("localityName", "stateOrProvinceName"),
+    ],
+}
+
+# If the trigger field is present, the required field must also be present.
+# Per VMC Requirements §7.1.4.2.2(j, s): jurisdiction (and statute) fields
+# describe the level of the Incorporating/Registration Agency (or the
+# Government Entity that established a Government Mark). A locality-level
+# value implies a state/province-level value must also be present; a
+# country-level entity legitimately has neither locality nor state/province.
+FIELD_REQUIRED_IF_FIELD_IS_PRESENT_BY_MARK_TYPE: dict[str, dict[str, str]] = {
     "All": {
-        "localityName": "stateOrProvinceName",
         "jurisdictionOfIncorporationLocalityName": "jurisdictionOfIncorporationStateOrProvinceName",
-        "stateOrProvinceName": "localityName",
-        "jurisdictionOfIncorporationStateOrProvinceName": "jurisdictionOfIncorporationLocalityName",
     },
     "Government Mark": {
         "statuteLocalityName": "statuteStateOrProvinceName",
-        "statuteStateOrProvinceName": "statuteLocalityName",
     },
 }
 
@@ -700,21 +719,31 @@ def get_certificate_metadata(pem_crt: bytes, *, domain=None) -> dict[str, Any]:
                         validation_errors.append(
                             f"The the certificate's subject is missing the required field {required_field}."
                         )
-                for key in FIELD_REQUIRED_IF_FIELD_IS_MISSING:
-                    if key in ["All", mark_type]:
-                        if key in FIELD_REQUIRED_IF_FIELD_IS_MISSING:
-                            for required_field in FIELD_REQUIRED_IF_FIELD_IS_MISSING[
-                                key
-                            ]:
-                                if required_field not in cert_subject:
-                                    alt_field = FIELD_REQUIRED_IF_FIELD_IS_MISSING[key][
-                                        required_field
-                                    ]
-                                    if alt_field not in cert_subject:
-                                        validation_errors.append(
-                                            f"{alt_field} is required in the certificate subject if {required_field} is not used in the certificate subject."
-                                        )
-                                        valid = False
+                either_or_pairs = list(
+                    EITHER_OR_SUBJECT_FIELDS_BY_MARK_TYPE.get("All", [])
+                ) + list(EITHER_OR_SUBJECT_FIELDS_BY_MARK_TYPE.get(mark_type, []))
+                for field_a, field_b in either_or_pairs:
+                    if field_a not in cert_subject and field_b not in cert_subject:
+                        validation_errors.append(
+                            f"At least one of {field_a} or {field_b} is required in the certificate subject."
+                        )
+                        valid = False
+                implies_rules: dict[str, str] = {}
+                implies_rules.update(
+                    FIELD_REQUIRED_IF_FIELD_IS_PRESENT_BY_MARK_TYPE.get("All", {})
+                )
+                implies_rules.update(
+                    FIELD_REQUIRED_IF_FIELD_IS_PRESENT_BY_MARK_TYPE.get(mark_type, {})
+                )
+                for trigger_field, required_field in implies_rules.items():
+                    if (
+                        trigger_field in cert_subject
+                        and required_field not in cert_subject
+                    ):
+                        validation_errors.append(
+                            f"{required_field} is required in the certificate subject when {trigger_field} is present."
+                        )
+                        valid = False
                 mark_type_fields = (
                     REQUIRED_SUBJECT_FIELDS_BY_MARK_TYPE[mark_type]
                     + OPTIONAL_SUBJECT_FIELDS_BY_MARK_TYPE[mark_type]
@@ -1062,6 +1091,15 @@ def parse_bimi_record(
                     if svg_metadata["width"] != svg_metadata["height"]:
                         warnings.append(
                             f"It is recommended for BIMI SVG dimensions to be square, not {svg_metadata['width']}x{svg_metadata['height']}."
+                        )
+                    title = svg_metadata.get("title")
+                    if isinstance(title, dict):
+                        title_text = str(title.get("#text", "") or "")
+                    else:
+                        title_text = str(title or "")
+                    if title_text and GENERIC_SVG_TITLE_REGEX.match(title_text):
+                        warnings.append(
+                            f"The SVG title '{title_text}' looks like a generator/template placeholder. The title element should be a descriptive name for the brand or mark."
                         )
                     svg_validation_errors = check_svg_requirements(svg_metadata)
                     if len(svg_validation_errors) > 0:

--- a/checkdmarc/bimi.py
+++ b/checkdmarc/bimi.py
@@ -1099,7 +1099,7 @@ def parse_bimi_record(
                         title_text = str(title or "")
                     if title_text and GENERIC_SVG_TITLE_REGEX.match(title_text):
                         warnings.append(
-                            f"The SVG title '{title_text}' looks like a generator/template placeholder. The title element should be a descriptive name for the brand or mark."
+                            f"The SVG title '{title_text}' looks like a generator/template placeholder. The <title> should be a short, human-readable name for the brand or mark — typically the organization name (e.g. the value of the certificate subject's organizationName field)."
                         )
                     svg_validation_errors = check_svg_requirements(svg_metadata)
                     if len(svg_validation_errors) > 0:

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -27,7 +27,7 @@ Please consider [sponsoring my work](https://github.com/sponsors/seanthegeek) if
   - Shows warnings when the DMARC record is made ineffective by `pct` or `sp` values
   - Checks for authorization records on reporting email addresses
 - BIMI
-  - Validation of the mark format and certificate
+  - Validation of the mark format and certificate against the [Minimum Security Requirements for Issuance of Mark Certificates](https://bimigroup.org/resources/VMC_Requirements_latest.pdf)
   - Parsing of the mark certificate
 - MX records
   - Preference


### PR DESCRIPTION
## Summary

- **Fix the BBC-style false negative (#242)** — per [VMC Requirements §7.1.4.2.2(j)](https://bimigroup.org/resources/VMC_Requirements_latest.pdf), entities whose Incorporating/Registration Agency operates at the country level (e.g. `bbc.co.uk`, jurisdiction = GB) MUST include only `jurisdictionCountryName`; state/province and locality MUST NOT be present. checkdmarc was rejecting such certificates and double-reporting the violation. The validation table is split into two clearer intents:
  - `EITHER_OR_SUBJECT_FIELDS_BY_MARK_TYPE` — pairs where at least one must be present (`localityName` / `stateOrProvinceName` only). Each pair is checked once, eliminating the duplicate-error bug.
  - `FIELD_REQUIRED_IF_FIELD_IS_PRESENT_BY_MARK_TYPE` — locality presence implies state/province must also be present (`jurisdictionOfIncorporationLocalityName` ⇒ `jurisdictionOfIncorporationStateOrProvinceName`, plus the parallel `statute*` fields for Government Marks per §7.1.4.2.2(s)).
- **Warn on placeholder SVG titles** — the BBC's BIMI image has a `<title>` of `bimi-svg-tiny-12-ps` (the SVG Tiny PS profile name leaked through as a placeholder). A new heuristic flags titles matching the `bimi-svg-tiny*` pattern, plus generic stand-ins (`Untitled`, bare `title`, lone `SVG`).
- **Documentation** — README and Sphinx index now link to the AuthIndicators Working Group's "Minimum Security Requirements for Issuance of Mark Certificates" so the validation rules are traceable to their source.

## Test plan

- [x] `ruff check` and `ruff format --check` clean.
- [x] Live BBC certificate (`vmc.digicert.com/ffc97feb-…pem`) now validates as `valid: True` with no `validation_errors`, where it previously returned two duplicate jurisdiction errors.
- [x] BBC SVG triggers the new title-placeholder warning. Realistic brand titles (`BBC`, `British Broadcasting Corporation`, `Logo SVG`) do not match the heuristic.
- [ ] CI: `coverage run tests.py` — the existing BIMI test (`testBIMI` against chase.com) is unchanged; please confirm its assertions still pass with network access enabled.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)