### PR TITLE
Fix BIMI query exception handling and properly support the lps tag

### DIFF
--- a/checkdmarc/bimi.py
+++ b/checkdmarc/bimi.py
@@ -150,8 +150,19 @@ class BIMICheckResult(TypedDict, total=False):
 
 
 BIMI_VERSION_REGEX_STRING = rf"v{WSP_REGEX}*={WSP_REGEX}*BIMI1{WSP_REGEX}*;"
+# lps= tag value, per draft-brand-indicators-for-message-identification-14
+# section 4.3.14:
+#     local-part-prefix-list = local-part-prefix *[ *WSP "," *WSP local-part-prefix ]
+#     local-part-prefix      = 1*63local-part-text
+#     local-part-text        = ALPHA / DIGIT / "-"
+BIMI_LPS_LOCAL_PART_REGEX = r"[A-Za-z0-9\-]{1,63}"
+BIMI_LPS_VALUE_REGEX = (
+    rf"{BIMI_LPS_LOCAL_PART_REGEX}"
+    rf"(?:{WSP_REGEX}*,{WSP_REGEX}*{BIMI_LPS_LOCAL_PART_REGEX})*"
+)
 BIMI_TAG_VALUE_REGEX_STRING = (
-    rf"([a-z]{{1,3}}){WSP_REGEX}*={WSP_REGEX}*(bimi1|{HTTPS_REGEX}|personal|brand)?"
+    rf"([a-z]{{1,3}}){WSP_REGEX}*={WSP_REGEX}*"
+    rf"(bimi1|{HTTPS_REGEX}|personal|brand|{BIMI_LPS_VALUE_REGEX})?"
 )
 BIMI_TAG_VALUE_REGEX = re.compile(BIMI_TAG_VALUE_REGEX_STRING, re.IGNORECASE)
 
@@ -870,11 +881,21 @@ def _query_bimi_record(
             pass
         except dns.resolver.NXDOMAIN:
             raise BIMIRecordNotFound("The domain does not exist.")
+        except BIMIError:
+            # Let BIMI-specific exceptions (BIMIRecordInWrongLocation) propagate
+            # — they were being silently swallowed because `raise` was missing.
+            raise
         except Exception as error:
-            BIMIRecordNotFound(error)
+            raise BIMIRecordNotFound(error)
 
-    except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+    except dns.resolver.NXDOMAIN:
         pass
+    except BIMIError:
+        # MultipleBIMIRecords and UnrelatedTXTRecordFoundAtBIMI are raised in
+        # the try-body above; propagate them so callers can act on the specific
+        # type instead of catching the broad BIMIRecordNotFound this clause
+        # used to convert everything to.
+        raise
     except Exception as error:
         raise BIMIRecordNotFound(error)
 
@@ -1132,9 +1153,10 @@ def parse_bimi_record(
                     f"Acceptable avp tag values are personal or brand, not {tag_value}"
                 )
         elif tag == "lps":
-            tag_value = tag_value.split(",")
-            for i in range(len(tag_value)):
-                tag_value[i] = tag_value[i].lower()
+            # Comma-separated local-parts; strip whitespace and lowercase
+            # for case-insensitive matching at delivery time.
+            selectors = [s.strip().lower() for s in tag_value.split(",")]
+            tags[tag]["value"] = selectors
 
     if parsed_dmarc_record and not tags["l"] == "":
         if parsed_dmarc_record["valid"] is False:

--- a/tests/test_bimi.py
+++ b/tests/test_bimi.py
@@ -5,6 +5,8 @@ import unittest
 from unittest.mock import patch
 from typing import Any, cast
 
+import dns.resolver
+
 import checkdmarc.bimi
 
 OFFLINE_MODE = os.environ.get("GITHUB_ACTIONS", "false").lower() == "true"
@@ -42,6 +44,136 @@ class Test(unittest.TestCase):
 
         self.assertTrue(cast(Any, results)["valid"])
         self.assertEqual(len(cast(Any, results)["warnings"]), 0)
+
+
+class TestLpsTag(unittest.TestCase):
+    """parse_bimi_record handles the lps= tag (comma-separated local-parts)"""
+
+    def testCommaSeparatedSelectors(self):
+        result = checkdmarc.bimi.parse_bimi_record("v=BIMI1; lps=news,billing,support")
+        self.assertEqual(result["tags"]["lps"]["value"], ["news", "billing", "support"])
+
+    def testSpacesAroundCommasAreStripped(self):
+        result = checkdmarc.bimi.parse_bimi_record(
+            "v=BIMI1; lps=news, billing, support"
+        )
+        self.assertEqual(result["tags"]["lps"]["value"], ["news", "billing", "support"])
+
+    def testSelectorsLowercased(self):
+        result = checkdmarc.bimi.parse_bimi_record("v=BIMI1; lps=News,Billing")
+        self.assertEqual(result["tags"]["lps"]["value"], ["news", "billing"])
+
+    def testSelectorCharacters(self):
+        """Per draft-bimi-14 § 4.3.14, local-part-text = ALPHA / DIGIT / '-' only"""
+        result = checkdmarc.bimi.parse_bimi_record(
+            "v=BIMI1; lps=sales-team,help-desk,info123"
+        )
+        self.assertEqual(
+            result["tags"]["lps"]["value"],
+            ["sales-team", "help-desk", "info123"],
+        )
+
+    def testSingleSelector(self):
+        result = checkdmarc.bimi.parse_bimi_record("v=BIMI1; lps=news")
+        self.assertEqual(result["tags"]["lps"]["value"], ["news"])
+
+    def testInvalidCharactersRejected(self):
+        """Underscores and dots are not allowed in local-part-text"""
+        self.assertRaises(
+            checkdmarc.bimi.BIMISyntaxError,
+            checkdmarc.bimi.parse_bimi_record,
+            "v=BIMI1; lps=help_desk",
+        )
+        self.assertRaises(
+            checkdmarc.bimi.BIMISyntaxError,
+            checkdmarc.bimi.parse_bimi_record,
+            "v=BIMI1; lps=info.support",
+        )
+
+
+class TestQueryBimiRecordPropagatesSpecificErrors(unittest.TestCase):
+    """Regression coverage for the exception-handling fix in _query_bimi_record.
+
+    Previously the broad ``except Exception`` clauses converted these specific
+    BIMI subclasses into ``BIMIRecordNotFound`` (or swallowed them entirely),
+    making them unreachable for callers.
+    """
+
+    def testMultipleRecordsPropagates(self):
+        """Two v=BIMI1 records at the selector raise MultipleBIMIRecords (not BIMIRecordNotFound)"""
+        with patch(
+            "checkdmarc.bimi.query_dns",
+            return_value=["v=BIMI1; l=https://a.example/a.svg", "v=BIMI1; l="],
+        ):
+            self.assertRaises(
+                checkdmarc.bimi.MultipleBIMIRecords,
+                checkdmarc.bimi._query_bimi_record,
+                "example.com",
+            )
+
+    def testUnrelatedRecordPropagates(self):
+        """A v=BIMI1 record alongside an unrelated TXT raises UnrelatedTXTRecordFoundAtBIMI"""
+        with patch(
+            "checkdmarc.bimi.query_dns",
+            return_value=["v=BIMI1; l=", "some other txt record"],
+        ):
+            self.assertRaises(
+                checkdmarc.bimi.UnrelatedTXTRecordFoundAtBIMI,
+                checkdmarc.bimi._query_bimi_record,
+                "example.com",
+            )
+
+    def testWrongLocationPropagates(self):
+        """A v=BIMI1 record at the apex (not at the selector) raises BIMIRecordInWrongLocation.
+
+        The selector returns NoAnswer, so the apex fallback runs and discovers
+        the record there. Before the fix, the missing ``raise`` keyword caused
+        this exception to be silently swallowed and the function returned None.
+        """
+
+        def fake_query_dns(target, rdtype, **kwargs):
+            if target == "default._bimi.example.com":
+                raise dns.resolver.NoAnswer()
+            if target == "example.com":
+                return ["v=BIMI1; l="]
+            return []
+
+        with patch("checkdmarc.bimi.query_dns", side_effect=fake_query_dns):
+            self.assertRaises(
+                checkdmarc.bimi.BIMIRecordInWrongLocation,
+                checkdmarc.bimi._query_bimi_record,
+                "example.com",
+            )
+
+    def testGenericExceptionStillConvertsToNotFound(self):
+        """Non-BIMI exceptions are still wrapped as BIMIRecordNotFound"""
+        with patch(
+            "checkdmarc.bimi.query_dns", side_effect=RuntimeError("network down")
+        ):
+            self.assertRaises(
+                checkdmarc.bimi.BIMIRecordNotFound,
+                checkdmarc.bimi._query_bimi_record,
+                "example.com",
+            )
+
+    def testApexGenericExceptionConvertsToNotFound(self):
+        """In the apex-fallback path, non-BIMI exceptions also wrap as BIMIRecordNotFound.
+
+        Before the fix, the apex-fallback exception clause was missing ``raise``,
+        so this exception was silently dropped and the function returned None.
+        """
+
+        def fake_query_dns(target, rdtype, **kwargs):
+            if target == "default._bimi.example.com":
+                raise dns.resolver.NoAnswer()
+            raise RuntimeError("network down")
+
+        with patch("checkdmarc.bimi.query_dns", side_effect=fake_query_dns):
+            self.assertRaises(
+                checkdmarc.bimi.BIMIRecordNotFound,
+                checkdmarc.bimi._query_bimi_record,
+                "example.com",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Three related bugs in `checkdmarc/bimi.py`:

1. **Specific BIMI exceptions were converted to `BIMIRecordNotFound`**. `_query_bimi_record`'s broad `except Exception as error:` caught `MultipleBIMIRecords` and `UnrelatedTXTRecordFoundAtBIMI` raised earlier in the same `try`-body and re-raised them as `BIMIRecordNotFound`. Callers couldn't distinguish "multiple records" or "unrelated TXT" from "no record found at all".

2. **`BIMIRecordInWrongLocation` was silently swallowed**. In the apex-fallback path, the catch-all clause was `BIMIRecordNotFound(error)` with no `raise` keyword, so the constructed exception was discarded. A record placed at the apex instead of the `_bimi` selector resulted in `_query_bimi_record` returning `None` (treated as "not found") instead of telling the caller about the misconfiguration.

3. **The `lps` tag was unreachable**. `parse_bimi_record` had an `elif tag == "lps":` branch (and a matching `BIMI_TAGS["lps"]` entry), but the grammar's value regex only accepted `bimi1`, an HTTPS URL, `personal`, or `brand` — never a comma-separated list of local-parts — so any record using `lps=...` was rejected with `BIMISyntaxError` before it could reach the branch. The branch also never wrote the parsed list back to `tags[tag]["value"]`.

   The `lps` tag is real per [draft-brand-indicators-for-message-identification-14 § 4.3.14](https://www.ietf.org/archive/id/draft-brand-indicators-for-message-identification-14.html):
   ```
   local-part-prefix-list = local-part-prefix *[ *WSP "," *WSP local-part-prefix ]
   local-part-prefix      = 1*63local-part-text
   local-part-text        = ALPHA / DIGIT / "-"
   ```
   Extended `BIMI_TAG_VALUE_REGEX_STRING` with a new alternative matching that ABNF and fixed the branch to write the parsed selectors back to the tag value (stripped and lowercased per § 4.5.7).

## Fixes

- Added `except BIMIError: raise` clauses in `_query_bimi_record` so BIMI-specific exceptions propagate while non-BIMI exceptions still convert to `BIMIRecordNotFound`.
- Added the missing `raise` keyword in the apex-fallback catch-all so `BIMIRecordInWrongLocation` reaches the caller.
- Added `BIMI_LPS_LOCAL_PART_REGEX` / `BIMI_LPS_VALUE_REGEX` matching the RFC ABNF and wired it into the tag-value regex.
- Wrote `tags[tag]["value"] = selectors` in the `lps` branch so the parsed list is actually returned.

## Tests

New regression tests in `tests/test_bimi.py`:
- `TestQueryBimiRecordPropagatesSpecificErrors` exercises all three previously-unreachable raise sites (`MultipleBIMIRecords`, `UnrelatedTXTRecordFoundAtBIMI`, `BIMIRecordInWrongLocation`) plus verifies that non-BIMI exceptions still wrap as `BIMIRecordNotFound`.
- `TestLpsTag` covers comma-separated parsing, whitespace handling, case-insensitive normalization, single-selector records, and rejection of characters (underscore, dot) outside the RFC ABNF.

## Test plan
- [ ] `GITHUB_ACTIONS=true python -m pytest tests/` passes (201 passed, 12 skipped)
- [ ] `ruff check`, `ruff format --check`, `pyright` all clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)