### PR TITLE
Coverage cleanup: _constants 100%, soa 100%, __init__ 98%

### DIFF
--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,6 +1,9 @@
 """Tests for checkdmarc._constants"""
 
+import importlib
+import os
 import unittest
+from unittest.mock import patch
 
 import checkdmarc
 
@@ -18,6 +21,76 @@ class Test(unittest.TestCase):
         self.assertIsInstance(constants.CACHE_MAX_LEN, int)
         self.assertIsInstance(constants.CACHE_MAX_AGE_SECONDS, int)
         self.assertIsInstance(constants.SYNTAX_ERROR_MARKER, str)
+
+
+class TestEnvironmentOverrideBranches(unittest.TestCase):
+    """Each cache-size / cache-age constant honors an env var of the same
+    name. The branches re-import the module under a patched environment
+    and assert the overridden value lands on the constant.
+    """
+
+    @staticmethod
+    def _reload_with_env(env_overrides):
+        """Reload checkdmarc._constants with the given env-var overrides applied."""
+        import checkdmarc._constants as constants
+
+        new_env = {**os.environ, **env_overrides}
+        with patch.dict(os.environ, new_env, clear=True):
+            importlib.reload(constants)
+        return constants
+
+    def tearDown(self):
+        """Restore the module to its baseline state so test ordering doesn't matter"""
+        import checkdmarc._constants as constants
+
+        importlib.reload(constants)
+
+    def testCacheMaxLenOverride(self):
+        constants = self._reload_with_env({"CACHE_MAX_LEN": "42"})
+        self.assertEqual(constants.CACHE_MAX_LEN, 42)
+        # Per-subsystem caches default to the umbrella value when their
+        # own override isn't set
+        self.assertEqual(constants.DNS_CACHE_MAX_LEN, 42)
+        self.assertEqual(constants.DNSSEC_CACHE_MAX_LEN, 42)
+        self.assertEqual(constants.SMTP_CACHE_MAX_LEN, 42)
+
+    def testCacheMaxAgeOverride(self):
+        constants = self._reload_with_env({"CACHE_MAX_AGE_SECONDS": "60"})
+        self.assertEqual(constants.CACHE_MAX_AGE_SECONDS, 60)
+        self.assertEqual(constants.DNS_CACHE_MAX_AGE_SECONDS, 60)
+        self.assertEqual(constants.DNSSEC_CACHE_MAX_AGE_SECONDS, 60)
+        self.assertEqual(constants.SMTP_CACHE_MAX_AGE_SECONDS, 60)
+
+    def testDnsCacheOverridesIndependent(self):
+        """Per-subsystem env vars take precedence over the umbrella default"""
+        constants = self._reload_with_env(
+            {
+                "DNS_CACHE_MAX_LEN": "100",
+                "DNS_CACHE_MAX_AGE_SECONDS": "30",
+            }
+        )
+        self.assertEqual(constants.DNS_CACHE_MAX_LEN, 100)
+        self.assertEqual(constants.DNS_CACHE_MAX_AGE_SECONDS, 30)
+
+    def testDnssecCacheOverridesIndependent(self):
+        constants = self._reload_with_env(
+            {
+                "DNSSEC_CACHE_MAX_LEN": "200",
+                "DNSSEC_CACHE_MAX_AGE_SECONDS": "120",
+            }
+        )
+        self.assertEqual(constants.DNSSEC_CACHE_MAX_LEN, 200)
+        self.assertEqual(constants.DNSSEC_CACHE_MAX_AGE_SECONDS, 120)
+
+    def testSmtpCacheOverridesIndependent(self):
+        constants = self._reload_with_env(
+            {
+                "SMTP_CACHE_MAX_LEN": "300",
+                "SMTP_CACHE_MAX_AGE_SECONDS": "180",
+            }
+        )
+        self.assertEqual(constants.SMTP_CACHE_MAX_LEN, 300)
+        self.assertEqual(constants.SMTP_CACHE_MAX_AGE_SECONDS, 180)
 
 
 if __name__ == "__main__":

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -399,5 +399,186 @@ class TestCheckDomainsBranches(unittest.TestCase):
         self.assertEqual(mock_sleep.call_count, 2)
 
 
+class TestCheckDomainsInputFiltering(unittest.TestCase):
+    """Edge cases in check_domains' input list normalization"""
+
+    @staticmethod
+    def _patch_all_checks(stack):
+        from contextlib import ExitStack  # noqa: F401
+
+        check_returns = {
+            "checkdmarc.test_dnssec": False,
+            "checkdmarc.check_soa": {"valid": True, "values": {}},
+            "checkdmarc.check_ns": {
+                "hostnames": ["ns1.example.com"],
+                "warnings": [],
+            },
+            "checkdmarc.check_mta_sts": {"valid": False, "error": "not found"},
+            "checkdmarc.check_mx": {"hosts": [], "warnings": []},
+            "checkdmarc.check_spf": {
+                "record": "v=spf1 -all",
+                "valid": True,
+                "warnings": [],
+            },
+            "checkdmarc.check_dmarc": {
+                "record": "v=DMARC1; p=reject",
+                "valid": True,
+                "warnings": [],
+                "tags": {},
+            },
+            "checkdmarc.check_smtp_tls_reporting": {
+                "valid": False,
+                "error": "not found",
+            },
+            "checkdmarc.check_bimi": {"valid": True, "warnings": []},
+        }
+        for target, return_value in check_returns.items():
+            stack.enter_context(patch(target, return_value=return_value))
+
+    def testEmptyStringsStripped(self):
+        """Empty-string domains are filtered out before any checks"""
+        from contextlib import ExitStack
+
+        with ExitStack() as stack:
+            self._patch_all_checks(stack)
+            result = checkdmarc.check_domains(["", "example.com", ""])
+        # Result is the single example.com (unwrapped)
+        self.assertEqual(cast(Any, result)["domain"], "example.com")
+
+    def testMtaStsValidPolicyPropagatesMxPatterns(self):
+        """A valid MTA-STS policy's mx patterns are forwarded to check_mx"""
+        from contextlib import ExitStack
+
+        check_returns = {
+            "checkdmarc.test_dnssec": False,
+            "checkdmarc.check_soa": {"valid": True, "values": {}},
+            "checkdmarc.check_ns": {
+                "hostnames": ["ns1.example.com"],
+                "warnings": [],
+            },
+            "checkdmarc.check_mta_sts": {
+                "valid": True,
+                "id": "20240101T010101",
+                "policy": {
+                    "mode": "enforce",
+                    "max_age": 86400,
+                    "mx": ["mail.example.com"],
+                },
+                "warnings": [],
+            },
+            "checkdmarc.check_spf": {
+                "record": "v=spf1 -all",
+                "valid": True,
+                "warnings": [],
+            },
+            "checkdmarc.check_dmarc": {
+                "record": "v=DMARC1; p=reject",
+                "valid": True,
+                "warnings": [],
+                "tags": {},
+            },
+            "checkdmarc.check_smtp_tls_reporting": {
+                "valid": False,
+                "error": "not found",
+            },
+            "checkdmarc.check_bimi": {"valid": True, "warnings": []},
+        }
+        with ExitStack() as stack:
+            for target, return_value in check_returns.items():
+                stack.enter_context(patch(target, return_value=return_value))
+            check_mx_mock = stack.enter_context(
+                patch(
+                    "checkdmarc.check_mx",
+                    return_value={"hosts": [], "warnings": []},
+                )
+            )
+            checkdmarc.check_domains(["example.com"])
+        # check_mx was called with the patterns extracted from the MTA-STS policy
+        self.assertEqual(
+            check_mx_mock.call_args.kwargs["mta_sts_mx_patterns"],
+            ["mail.example.com"],
+        )
+
+
+class TestResultsToCsvRowsExtraBranches(unittest.TestCase):
+    """Branches in results_to_csv_rows not covered by the existing tests"""
+
+    @staticmethod
+    def _base_result_with_bimi(error=False):
+        result = {
+            "domain": "example.com",
+            "base_domain": "example.com",
+            "dnssec": True,
+            "ns": {"hostnames": [], "warnings": []},
+            "mx": {"hosts": [], "warnings": []},
+            "mta_sts": {"valid": False, "error": "not found"},
+            "spf": {"record": "v=spf1 -all", "valid": True, "warnings": []},
+            "dmarc": {
+                "record": "v=DMARC1; p=reject",
+                "location": "example.com",
+                "valid": True,
+                "tags": {
+                    "adkim": {"value": "r"},
+                    "aspf": {"value": "r"},
+                    "fo": {"value": ["0"]},
+                    "p": {"value": "reject"},
+                    "pct": {"value": 100},
+                    "rf": {"value": ["afrf"]},
+                    "ri": {"value": 86400},
+                    "sp": {"value": "reject"},
+                },
+                "warnings": [],
+            },
+            "smtp_tls_reporting": {"valid": False, "error": "not found"},
+            "bimi": {
+                "valid": False if error else True,
+                "selector": "default",
+                "warnings": [],
+                "tags": {
+                    "l": {"value": "https://example.com/logo.svg"},
+                    "a": {"value": "https://example.com/cert.pem"},
+                },
+            },
+        }
+        if error:
+            result["bimi"]["error"] = "fetch failed"
+        return result
+
+    def testBimiErrorFlattensTagValues(self):
+        """When the BIMI result is in error and tags are present, l/a tag
+        values land as bimi_l / bimi_a columns"""
+        rows = checkdmarc.results_to_csv_rows(
+            cast(checkdmarc.DomainCheckResult, self._base_result_with_bimi(error=True))
+        )
+        row = rows[0]
+        self.assertEqual(row["bimi_error"], "fetch failed")
+        self.assertEqual(row["bimi_l"], "https://example.com/logo.svg")
+        self.assertEqual(row["bimi_a"], "https://example.com/cert.pem")
+
+    def testTlsKeyErrorPath(self):
+        """When MX hosts lack 'starttls'/'tls' keys (e.g., skip_tls=True),
+        the KeyError handler leaves tls/starttls as None"""
+        result = self._base_result_with_bimi(error=False)
+        del result["bimi"]
+        # Add an MX host without starttls/tls keys
+        result["mx"] = {
+            "hosts": [
+                {
+                    "preference": 10,
+                    "hostname": "mail.example.com",
+                    "addresses": ["192.0.2.1"],
+                }
+            ],
+            "warnings": [],
+        }
+        rows = checkdmarc.results_to_csv_rows(
+            cast(checkdmarc.DomainCheckResult, result)
+        )
+        row = rows[0]
+        # KeyError on starttls -> tls and starttls remain None
+        self.assertIsNone(row["tls"])
+        self.assertIsNone(row["starttls"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_soa.py
+++ b/tests/test_soa.py
@@ -72,6 +72,42 @@ class Test(unittest.TestCase):
             result = checkdmarc.soa.check_soa("example.com")
             self.assertIn("error", result)
 
+    def testRnameEmptyLocalPart(self):
+        """A leading dot in the RNAME (empty local part) raises ValueError"""
+        self.assertRaises(
+            ValueError,
+            checkdmarc.soa.soa_rname_to_email,
+            ".example.com.",
+        )
+
+    def testParseSoaStringNonIntegerField(self):
+        """A non-integer in a numeric field raises ValueError"""
+        self.assertRaises(
+            ValueError,
+            checkdmarc.soa.parse_soa_string,
+            "ns1.example.com. admin.example.com. notanumber 3600 900 604800 86400",
+        )
+
+    def testParseSoaStringNegativeField(self):
+        """A negative integer (outside the u32 range) raises ValueError"""
+        self.assertRaises(
+            ValueError,
+            checkdmarc.soa.parse_soa_string,
+            "ns1.example.com. admin.example.com. -1 3600 900 604800 86400",
+        )
+
+    def testCheckSoaParseError(self):
+        """get_soa_record succeeds but parse_soa_string fails — error result with the record"""
+        # 7 fields but one is unparseable, so parse_soa_string raises
+        bad_record = (
+            "ns1.example.com. admin.example.com. notanumber 3600 900 604800 86400"
+        )
+        with patch("checkdmarc.soa.get_soa_record", return_value=bad_record):
+            result = checkdmarc.soa.check_soa("example.com")
+        self.assertIn("error", result)
+        # The original record is preserved on the failure result
+        self.assertEqual(result["record"], bad_record)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Last cleanup pass on the small per-file coverage gaps that earlier rounds skipped.

| File | Before | After |
|------|--------|-------|
| `_constants.py` | 79% | **100%** |
| `soa.py` | 89% | **100%** |
| `__init__.py` | 92% | **98%** |

### Tests added

- **`tests/test_constants.py`** — `TestEnvironmentOverrideBranches` reloads `checkdmarc._constants` under a `patch.dict(os.environ, ...)` context and asserts that each cache-size and cache-age env var (`CACHE_MAX_LEN`, `CACHE_MAX_AGE_SECONDS`, plus the per-subsystem `DNS_*`, `DNSSEC_*`, `SMTP_*` overrides) lands on the corresponding constant. `tearDown` restores the module so test ordering is unaffected.
- **`tests/test_soa.py`** — covers the empty-local-part RNAME branch (e.g. `.example.com.`), the non-integer u32 field branch, the out-of-range u32 branch, and the `check_soa` parse-error branch (where `get_soa_record` succeeds but `parse_soa_string` raises — the failure result still carries the original record).
- **`tests/test_init.py`** — empty-string filter inside `check_domains`, MTA-STS-policy mx-pattern propagation to `check_mx`, BIMI-error CSV row flattening `l`/`a` tag values to `bimi_l` / `bimi_a` columns, and the TLS / STARTTLS `KeyError` fallback for MX hosts without those keys (e.g. when `skip_tls=True`).

## Test plan
- [ ] `GITHUB_ACTIONS=true python -m pytest tests/` passes (439 passed, 12 skipped)
- [ ] `ruff check`, `ruff format --check`, `pyright` (1.1.409) all clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)