### PR TITLE
Release 5.15.5

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -24,7 +24,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install pyright
+        # Force the latest ruff and pyright so lint/typecheck rules
+        # track upstream and surface new issues promptly. AGENTS.md
+        # requires the latest pyright in particular.
+        pip install --upgrade ruff pyright
     - name: Test building documentation
       run: |
         cd docs
@@ -34,10 +37,28 @@ jobs:
     - name: Check formatting with ruff
       run: ruff format --check .
     - name: Type-check with pyright
+      env:
+        # Override the pyright Python wrapper's pinned bundle so it
+        # downloads whatever upstream tagged as ``latest`` at run time,
+        # not just whatever was current when the wheel was published.
+        PYRIGHT_PYTHON_FORCE_VERSION: latest
       run: pyright
     - name: Run unit tests
       run: |
-        coverage run -m pytest tests/
-        coverage json
+        pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy tests/
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false
+    - name: Upload test results to Codecov
+      # Feeds Codecov Test Analytics (flaky-test detection, per-test
+      # history). Runs even on test failure so failed cases still get
+      # reported. Uses the same CODECOV_TOKEN as the coverage upload.
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./junit.xml
     - name: Test building packages
       run: hatch build

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -44,8 +44,11 @@ jobs:
         PYRIGHT_PYTHON_FORCE_VERSION: latest
       run: pyright
     - name: Run unit tests
+      # ``python -m pytest`` (not bare ``pytest``) so cwd lands on
+      # sys.path[0] — checkdmarc isn't pip-installed in CI, so the
+      # tests need to import the in-repo package directly.
       run: |
-        pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy tests/
+        python -m pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy tests/
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+junit.xml
 *.cover
 .hypothesis/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 5.15.5
+
+### Fixes
+
+- BIMI: stop masking `MultipleBIMIRecords`, `UnrelatedTXTRecordFoundAtBIMI`,
+  and `BIMIRecordInWrongLocation` behind `BIMIRecordNotFound`. The
+  apex-fallback handler also had a missing `raise`, so a record placed at
+  the apex (instead of the `_bimi` selector) was silently treated as
+  "not found" (#246).
+- BIMI: properly support the `lps=` tag (per
+  [draft-bimi-14 § 4.3.14](https://www.ietf.org/archive/id/draft-brand-indicators-for-message-identification-14.html)).
+  The grammar previously rejected any `lps=` value, and the parser branch
+  for it never wrote the parsed selectors back to the tag value (#246).
+- DMARC: stop masking `DMARCRecordInWrongLocation` behind
+  `DMARCRecordNotFound` in `_query_dmarc_record`'s apex-fallback path (#248).
+- SMTP: the cache-write paths in `test_tls` and `test_starttls` used
+  `if cache:`, which is falsy for an empty `ExpiringDict`. The first
+  cache entry was silently dropped, so subsequent SMTP probes kept
+  hitting the network (#244).
+- SPF: `parse_spf_record`'s redirect handler used `except DNSException as
+  error:`, shadowing the function-level `error` accumulator. Python
+  deletes the name on except-block exit, so the trailing `if error:`
+  raised `UnboundLocalError` (#247).
+
+### Changes
+
+- Test suite reorganized from a single `tests.py` into per-module
+  files under `tests/`. Network-dependent tests are paired with
+  fully-mocked counterparts; CI runs the mocked branch, local runs
+  the real-network branch.
+- Project test coverage raised from 67% to 96%; every module is now
+  at ≥ 90%. Coverage and test results are uploaded to Codecov on
+  each CI run.
+
 ## 5.15.4
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@
   apex-fallback handler also had a missing `raise`, so a record placed at
   the apex (instead of the `_bimi` selector) was silently treated as
   "not found" (#246).
-- BIMI: properly support the `lps=` tag (per
-  [draft-bimi-14 § 4.3.14](https://www.ietf.org/archive/id/draft-brand-indicators-for-message-identification-14.html)).
-  The grammar previously rejected any `lps=` value, and the parser branch
-  for it never wrote the parsed selectors back to the tag value (#246).
+- BIMI: extend the grammar to accept the canonical `lps=` value
+  format — a comma-separated list of local-part selectors per
+  [draft-bimi-14 § 4.3.14](https://www.ietf.org/archive/id/draft-brand-indicators-for-message-identification-14.html).
+  The grammar previously only accepted values matching one of
+  `bimi1`, an HTTPS URL, `personal`, or `brand`, so the canonical
+  comma-separated form raised `BIMISyntaxError`. Also fix the parser
+  to write the parsed selector list back to the tag value (#246).
 - DMARC: stop masking `DMARCRecordInWrongLocation` behind
   `DMARCRecordNotFound` in `_query_dmarc_record`'s apex-fallback path (#248).
 - SMTP: the cache-write paths in `test_tls` and `test_starttls` used

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # checkdmarc
 
 [![Python tests](https://github.com/domainaware/checkdmarc/actions/workflows/python-tests.yaml/badge.svg)](https://github.com/domainaware/checkdmarc/actions/workflows/python-tests.yaml)
+[![Code Coverage](https://codecov.io/gh/domainaware/checkdmarc/branch/main/graph/badge.svg)](https://codecov.io/gh/domainaware/checkdmarc)
 [![PyPI](https://img.shields.io/pypi/v/checkdmarc)](https://pypi.org/project/checkdmarc/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/checkdmarc?color=blue)](https://pypistats.org/packages/checkdmarc)
 

--- a/checkdmarc/_constants.py
+++ b/checkdmarc/_constants.py
@@ -19,7 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-__version__ = "5.15.4"
+__version__ = "5.15.5"
 
 OS = platform.system()
 OS_RELEASE = platform.release()

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,6 @@ codecov>=2.1.10
 autopep8
 hatch
 pytest
+pytest-cov
 ruff
 black


### PR DESCRIPTION
## Summary

Release 5.15.5 — bundles the bug fixes that landed since 5.15.4, the test-suite reorganization, and the coverage jump from 67% to 96%, plus Codecov integration in CI.

### Fixes (already merged on `main`)

- **BIMI**: stop masking `MultipleBIMIRecords`, `UnrelatedTXTRecordFoundAtBIMI`, and `BIMIRecordInWrongLocation` behind `BIMIRecordNotFound`. The apex-fallback handler also had a missing `raise`, so a record placed at the apex was silently treated as "not found" (#246).
- **BIMI**: extend the grammar to accept the canonical `lps=` value format — a comma-separated list of local-part selectors per [draft-bimi-14 § 4.3.14](hhttps://www.ietf.org/archive/id/draft-brand-indicators-for-message-identification-14.html#name-local-part-selectors). The grammar previously only accepted values matching one of `bimi1`, an HTTPS URL, `personal`, or `brand`, so the canonical comma-separated form raised `BIMISyntaxError`. Also fix the parser to write the parsed selector list back to the tag value (#246).
- **DMARC**: stop masking `DMARCRecordInWrongLocation` behind `DMARCRecordNotFound` in `_query_dmarc_record`'s apex-fallback path (#248).
- **SMTP**: the cache-write paths in `test_tls` and `test_starttls` used `if cache:`, which is falsy for an empty `ExpiringDict`. First cache entry was silently dropped; subsequent probes kept hitting the network (#244).
- **SPF**: `parse_spf_record`'s redirect handler used `except DNSException as error:`, shadowing the function-level `error` accumulator. Python deletes the name on except-block exit, so the trailing `if error:` raised `UnboundLocalError` (#247).

### New in this PR

- Bump `__version__` to `5.15.5` and prepend a CHANGELOG entry.
- **Codecov**: switch the test step to `python -m pytest --cov --cov-report=xml --junitxml=junit.xml`, add `codecov/codecov-action@v5` and `codecov/test-results-action@v1` upload steps. Same minimal `codecov.yml` as parsedmarc (project status informational, patch enforced). Codecov badge added to the README between the build and PyPI badges.
- Force latest `ruff` and `pyright` in CI (`pip install --upgrade`, plus `PYRIGHT_PYTHON_FORCE_VERSION=latest` for the pyright node bundle) so lint/typecheck rules track upstream.
- Add `pytest-cov` to `requirements.txt`; gitignore `junit.xml`.

## Test plan
- [x] `GITHUB_ACTIONS=true python -m pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy tests/` — 439 passed, 12 skipped
- [x] `ruff check`, `ruff format --check`, `pyright` (latest) all clean locally
- [ ] CI green on this PR (Codecov action requires `CODECOV_TOKEN` repo secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)