### PR TITLE
5.16.1: simplify the removed-tag warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@
 ### Changes
 
 - Simplify the warning emitted for `pct`/`rf`/`ri` to just "Support for
-  the {tag} tag was removed in RFC 9989". The previous wording added a
-  clause about the value being "preserved for older DMARC readers but
-  not validated" that wasn't actionable for the user.
+  the {tag} tag was removed in RFC 9989".
 
 ## 5.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 5.16.1
+
+### Changes
+
+- Simplify the warning emitted for `pct`/`rf`/`ri` to just "Support for
+  the {tag} tag was removed in RFC 9989". The previous wording added a
+  clause about the value being "preserved for older DMARC readers but
+  not validated" that wasn't actionable for the user.
+
 ## 5.16.0
 
 ### Changes

--- a/checkdmarc/_constants.py
+++ b/checkdmarc/_constants.py
@@ -19,7 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-__version__ = "5.16.0"
+__version__ = "5.16.1"
 
 OS = platform.system()
 OS_RELEASE = platform.release()

--- a/checkdmarc/dmarc.py
+++ b/checkdmarc/dmarc.py
@@ -1279,11 +1279,7 @@ def parse_dmarc_record(
                 f"Duplicate {duplicate_tags_str} tags are not permitted"
             )
         if tag in removed_tags:
-            warnings.append(
-                f"Support for the {tag} tag was removed in RFC 9989; "
-                "the value is preserved for older DMARC readers but is "
-                "not validated."
-            )
+            warnings.append(f"Support for the {tag} tag was removed in RFC 9989")
             continue
         value = pair[1].lower().strip()
         tags[tag] = {"value": value, "explicit": True}


### PR DESCRIPTION
## Summary

- Trim the `pct`/`rf`/`ri` warning to just "Support for the {tag} tag was removed in RFC 9989" — the previous wording had an awkward clause about preserving the value for older readers.
- Bump version to 5.16.1 and add a CHANGELOG entry.

## Test plan

- [x] `pytest tests/test_dmarc.py` — 86/86 pass (the existing `testRFC9989PctRemovedWarning` / `RfRemovedWarning` / `RiRemovedWarning` substring assertions still match the shorter message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)