### PR TITLE
Add warning for deprecated Sender ID TXT records

### DIFF
--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -58,7 +58,7 @@ AFTER_ALL_REGEX_STRING = r"(?:^|\s)[+\-~?]?all\s+(.+)"
 SPF_MECHANISM_REGEX = re.compile(SPF_MECHANISM_REGEX_STRING, re.IGNORECASE)
 AFTER_ALL_REGEX = re.compile(AFTER_ALL_REGEX_STRING, re.IGNORECASE)
 SENDER_ID_VERSION_TAG_REGEX = re.compile(
-    r'^"?v=spf2\.0/(?:pra|mfrom|mfrom,pra|pra,mfrom)(?:\s|$)',
+    r"^v=spf2\.0/(?:pra|mfrom)(?:,(?:pra|mfrom))?(?:\s|$)",
     re.IGNORECASE,
 )
 
@@ -471,9 +471,8 @@ def query_spf_record(
                 )
                 continue
 
-            if (
-                cleaned_record_lower == txt_prefix
-                or cleaned_record_lower.startswith(f"{txt_prefix} ")
+            if cleaned_record_lower == txt_prefix or cleaned_record_lower.startswith(
+                f"{txt_prefix} "
             ):
                 spf_txt_records.append(record)
             elif cleaned_record_lower.startswith(txt_prefix):

--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -57,6 +57,10 @@ AFTER_ALL_REGEX_STRING = r"(?:^|\s)[+\-~?]?all\s+(.+)"
 
 SPF_MECHANISM_REGEX = re.compile(SPF_MECHANISM_REGEX_STRING, re.IGNORECASE)
 AFTER_ALL_REGEX = re.compile(AFTER_ALL_REGEX_STRING, re.IGNORECASE)
+SENDER_ID_VERSION_TAG_REGEX = re.compile(
+    r'^"?v=spf2\.0/(?:pra|mfrom|mfrom,pra|pra,mfrom)(?:\s|$)',
+    re.IGNORECASE,
+)
 
 # Detect an 'all' mechanism glued to the previous term without required
 # whitespace, e.g., "ip4:203.0.113.7~all". This should be rejected as a
@@ -455,9 +459,24 @@ def query_spf_record(
                 warnings.append("A TXT record with undecodable characters was skipped.")
                 continue
 
-            if record.strip('"').startswith(txt_prefix):
+            cleaned_record = record.strip().strip('"')
+            cleaned_record_lower = cleaned_record.lower()
+
+            if SENDER_ID_VERSION_TAG_REGEX.match(cleaned_record):
+                warnings.append(
+                    "A deprecated Sender ID record was found. Sender ID "
+                    "using spf2.0/pra or spf2.0/mfrom was deprecated and "
+                    "should be removed: "
+                    f"{record}"
+                )
+                continue
+
+            if (
+                cleaned_record_lower == txt_prefix
+                or cleaned_record_lower.startswith(f"{txt_prefix} ")
+            ):
                 spf_txt_records.append(record)
-            elif record.startswith(txt_prefix):
+            elif cleaned_record_lower.startswith(txt_prefix):
                 raise SPFRecordNotFound(
                     "According to RFC 7208 section 4.5, an SPF record should be"
                     f" equal to {txt_prefix} or begin with {txt_prefix} "

--- a/tests/test_spf.py
+++ b/tests/test_spf.py
@@ -577,6 +577,60 @@ class Test(unittest.TestCase):
         self.assertEqual(parsed_record["parsed"]["all"], "fail")
 
     @mocked_only
+    def testSenderIDRecordsWarnMocked(self):
+        """Deprecated Sender ID TXT records produce SPF warnings"""
+        sender_id_records = [
+            "v=spf2.0/pra ip4:192.0.2.0/24 ~all",
+            "v=spf2.0/mfrom ip4:192.0.2.0/24 ~all",
+            "v=spf2.0/mfrom,pra ip4:192.0.2.0/24 ~all",
+            "v=spf2.0/pra,mfrom ip4:192.0.2.0/24 ~all",
+        ]
+
+        for sender_id_record in sender_id_records:
+            with self.subTest(sender_id_record=sender_id_record):
+                records = ["v=spf1 -all", sender_id_record]
+                with patch("checkdmarc.spf.query_dns", return_value=records):
+                    result = checkdmarc.spf.query_spf_record("example.com")
+
+                self.assertEqual(result["record"], "v=spf1 -all")
+                self.assertTrue(
+                    any(
+                        "deprecated Sender ID record" in warning
+                        for warning in result["warnings"]
+                    )
+                )
+
+    @mocked_only
+    def testInvalidSPFVersionTagsRejectedMocked(self):
+        """Invalid SPF version-like TXT records are rejected"""
+        invalid_records = [
+            "v=spf10 -all",
+            "v=spf1foo -all",
+        ]
+
+        for record in invalid_records:
+            with self.subTest(record=record):
+                with patch("checkdmarc.spf.query_dns", return_value=[record]):
+                    with self.assertRaises(checkdmarc.spf.SPFRecordNotFound):
+                        checkdmarc.spf.query_spf_record("example.com")
+
+    @mocked_only
+    def testSPFVersionMatchingIsCaseInsensitiveMocked(self):
+        """Uppercase SPF version tags are accepted"""
+        with patch("checkdmarc.spf.query_dns", return_value=["V=SPF1 -all"]):
+            result = checkdmarc.spf.query_spf_record("example.com")
+
+        self.assertEqual(result["record"], "V=SPF1 -all")
+
+    @mocked_only
+    def testSPFVersionMatchingAllowsSurroundingWhitespaceMocked(self):
+        """SPF records with surrounding whitespace are accepted"""
+        with patch("checkdmarc.spf.query_dns", return_value=["  v=spf1 -all  "]):
+            result = checkdmarc.spf.query_spf_record("example.com")
+
+        self.assertEqual(result["record"], "  v=spf1 -all  ")
+
+    @mocked_only
     def testJunkAfterAllMocked(self):
         """Warn about text after the all mechanism (mocked; ip4 + -all needs no DNS)"""
         rec = "v=spf1 ip4:213.5.39.110 -all MS=83859DAEBD1978F9A7A67D3"


### PR DESCRIPTION
Sender ID was deprecated in 2018 and these records are no longer recommended.

Adds a warning when deprecated Sender ID TXT records are detected during SPF checks.

This change detects:
- v=spf2.0/pra
- v=spf2.0/mfrom

The warning is added during SPF TXT record discovery and does not change SPF parsing or validation behaviour.

Example warning:

"A deprecated Sender ID record was found. Sender ID using spf2.0/pra or spf2.0/mfrom was deprecated and should be removed."

Tested against domains containing both valid SPF and legacy Sender ID TXT records.