### PR TITLE
More verbose nxdomain message

### DIFF
--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -1197,7 +1197,7 @@ def parse_spf_record(
                         "lookups (RFC 7208 § 4.6.4)",
                         void_dns_lookups=total_void_dns_lookups,
                     )
-            warnings.append(f"{value or domain}: {str(warning)}")
+            warnings.append(f"Error when processing {value or domain}: {str(warning)}")
 
     if error:
         error_result: ParsedSPFRecordError = {

--- a/checkdmarc/utils.py
+++ b/checkdmarc/utils.py
@@ -311,7 +311,7 @@ def get_a_records(
                 retries=retries,
             )
         except dns.resolver.NXDOMAIN:
-            raise DNSExceptionNXDOMAIN("The domain does not exist.")
+            raise DNSExceptionNXDOMAIN(f"The domain {domain} does not exist.")
         except dns.resolver.NoAnswer:
             # Sometimes a domain will only have A or AAAA records, but not both
             pass
@@ -406,7 +406,7 @@ def get_txt_records(
             retries=retries,
         )
     except dns.resolver.NXDOMAIN:
-        raise DNSExceptionNXDOMAIN("The domain does not exist.")
+        raise DNSExceptionNXDOMAIN(f"The domain {domain} does not exist.")
     except dns.resolver.NoAnswer:
         raise DNSException(f"The domain {domain} does not have any TXT records.")
     except Exception as error:
@@ -452,7 +452,7 @@ def get_soa_record(
             retries=retries,
         )[0]
     except dns.resolver.NXDOMAIN:
-        raise DNSExceptionNXDOMAIN("The domain does not exist.")
+        raise DNSExceptionNXDOMAIN(f"The domain {domain} does not exist.")
     except dns.resolver.NoAnswer:
         raise DNSException(f"The domain {domain} does not have an SOA record.")
     except Exception as error:
@@ -501,7 +501,7 @@ def get_nameservers(
             retries=retries,
         )
     except dns.resolver.NXDOMAIN:
-        raise DNSExceptionNXDOMAIN("The domain does not exist.")
+        raise DNSExceptionNXDOMAIN(f"The domain {domain} does not exist.")
     except dns.resolver.NoAnswer:
         pass
     except Exception as error:
@@ -571,7 +571,7 @@ def get_mx_records(
             hosts.append({"preference": preference, "hostname": hostname})
         hosts = sorted(hosts, key=lambda h: (h["preference"], h["hostname"]))
     except dns.resolver.NXDOMAIN:
-        raise DNSExceptionNXDOMAIN("The domain does not exist.")
+        raise DNSExceptionNXDOMAIN(f"The domain {domain} does not exist.")
     except dns.resolver.NoAnswer:
         pass
     except Exception as error:

--- a/tests/test_spf.py
+++ b/tests/test_spf.py
@@ -224,7 +224,7 @@ class Test(unittest.TestCase):
         domain = "seanthegeek.net"
         results = checkdmarc.spf.parse_spf_record(spf_record, domain)
         self.assertIn(
-            "{0}: An mx mechanism points to {0}, but that domain/subdomain does not have any MX records.".format(
+            "Error when processing {0}: An mx mechanism points to {0}, but that domain/subdomain does not have any MX records.".format(
                 domain
             ),
             results["warnings"],
@@ -601,8 +601,9 @@ class Test(unittest.TestCase):
             mock_dns.side_effect = dns.resolver.NXDOMAIN()
             results = checkdmarc.spf.parse_spf_record(spf_record, domain)
 
-        self.assertTrue(
-            "example.doesnotexist: The domain does not exist." in results["warnings"]
+        self.assertIn(
+            "Error when processing example.doesnotexist: The domain does not exist.",
+            results["warnings"],
         )
         self.assertEqual(results["dns_lookups"], 1)
 
@@ -667,7 +668,7 @@ class Test(unittest.TestCase):
         with patch("checkdmarc.spf.get_mx_records", return_value=[]):
             results = checkdmarc.spf.parse_spf_record(spf_record, domain)
         self.assertIn(
-            "{0}: An mx mechanism points to {0}, but that domain/subdomain does not have any MX records.".format(
+            "Error when processing {0}: An mx mechanism points to {0}, but that domain/subdomain does not have any MX records.".format(
                 domain
             ),
             results["warnings"],


### PR DESCRIPTION
Let's assume we are processing an SPF record: `v=spf1 mx -all` for domain `example.com` having a single MX record of `mail.example.com` which doesn't exist.

Previously the error message was `example.com: the domain does not exist.` which is false. After this change, the message would be `Error when processing example.com: the domain mail.example.com does not exist.`.