### PR TITLE
Accept uppercase SPF macro letters (RFC 7208 §7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Accept uppercase SPF macro letters (e.g. `%{S}`), which are valid per RFC 7208 §7.1 ([PR #257](https://github.com/domainaware/checkdmarc/pull/257))
+
 ## 5.17.0
 
 ### Added

--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -341,9 +341,11 @@ def _validate_spf_macros(
         if not body:
             _raise_macro_syntax_error(value, i, domain, syntax_error_marker)
 
-        # First char: macro-letter
+        # First char: macro-letter. Per RFC 7208 §7.1, uppercase macro letters
+        # (e.g. %{S}) are valid: they expand exactly as their lowercase
+        # equivalents and are then URL-encoded. Accept either case.
         letter = body[0]
-        if letter not in MACRO_LETTERS:
+        if letter.lower() not in MACRO_LETTERS:
             _raise_macro_syntax_error(value, i + 2, domain, syntax_error_marker)
 
         rest = body[1:]

--- a/tests/test_spf.py
+++ b/tests/test_spf.py
@@ -427,6 +427,30 @@ class Test(unittest.TestCase):
             domain,
         )
 
+    def testSPFUppercaseMacroLetterAccepted(self):
+        """Uppercase macro letters are valid (RFC 7208 §7.1)
+
+        Per RFC 7208 §7.1, uppercase macro letters expand exactly as their
+        lowercase equivalents and are then URL-encoded, so a value like
+        ``%{S}`` must not be rejected as a syntax error.
+        """
+        spf_record = "v=spf1 -all exp=%{S}.explain.example.com"
+        domain = "example.com"
+        results = checkdmarc.spf.parse_spf_record(spf_record, domain)
+        self.assertEqual(results["parsed"]["exp"], "%{S}.explain.example.com")
+        self.assertEqual(results["dns_lookups"], 0)
+
+    def testSPFUnknownMacroLetterStillRejected(self):
+        """Macro letters outside the RFC 7208 set still raise SPFSyntaxError"""
+        spf_record = "v=spf1 -all exp=%{z}"
+        domain = "example.com"
+        self.assertRaises(
+            checkdmarc.spf.SPFSyntaxError,
+            checkdmarc.spf.parse_spf_record,
+            spf_record,
+            domain,
+        )
+
     def testUndecodableCharactersInNonSPFRecord(self):
         """Non-SPF TXT records with undecodable characters should be ignored with a warning"""
         domain = "example.com"


### PR DESCRIPTION
### Problem

`checkdmarc` rejects valid SPF records that use **uppercase macro letters**.
Per [RFC 7208 §7.1](https://www.rfc-editor.org/rfc/rfc7208#section-7.1), a
macro expansion may use either the lowercase letter or its uppercase
counterpart; the uppercase form expands exactly as the lowercase one and the
result is then URL-encoded. So a record such as:

```
v=spf1 -all exp=%{S}.explain.example.com
```

is well-formed, but `parse_spf_record` raises:

```
SPFSyntaxError: Invalid SPF macro syntax at position 2 (marked with ➞) in value: %{➞S}.explain.example.com
```

### Cause

In `_validate_spf_macros` the macro letter was compared case-sensitively
against the lowercase `MACRO_LETTERS` set:

```python
letter = body[0]
if letter not in MACRO_LETTERS:
    _raise_macro_syntax_error(...)
```

Any uppercase macro letter therefore failed validation even though it is
legal per the RFC.

### Fix

Compare the letter case-insensitively (`letter.lower() not in MACRO_LETTERS`).
Letters outside the macro set are still rejected.

### Tests

Added two unit tests to `tests/test_spf.py`:

- `testSPFUppercaseMacroLetterAccepted` — `%{S}` parses without error (offline,
  asserts `dns_lookups == 0`).
- `testSPFUnknownMacroLetterStillRejected` — `%{z}` still raises
  `SPFSyntaxError`, confirming the validation isn't loosened beyond the RFC set.

Full `tests/test_spf.py` passes locally (`GITHUB_ACTIONS=true python -m unittest tests.test_spf`).

---

*Disclosure: I used an AI assistant to help investigate this issue and draft
the patch, working under my direction. I reviewed the RFC, verified the fix and
the tests (red → green), and understand the change.*
