### PR TITLE
Release 5.17.2: discard SPF TXT records with leading whitespace (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.17.2
+
+### Fixed
+
+- Discard TXT records with leading whitespace instead of treating them as valid SPF records, since RFC 7208 section 4.5 requires a record to begin with exactly `v=spf1` ([issue #258](https://github.com/domainaware/checkdmarc/issues/258))
+
 ## 5.17.1
 
 ### Fixed

--- a/checkdmarc/_constants.py
+++ b/checkdmarc/_constants.py
@@ -19,7 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-__version__ = "5.17.1"
+__version__ = "5.17.2"
 
 OS = platform.system()
 OS_RELEASE = platform.release()

--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -463,7 +463,14 @@ def query_spf_record(
                 warnings.append("A TXT record with undecodable characters was skipped.")
                 continue
 
-            cleaned_record = record.strip().strip('"')
+            # Strip only the surrounding quotes, not whitespace. Per RFC 7208
+            # section 4.5, "discard records that do not begin with a version
+            # section of exactly 'v=spf1'", and the ABNF (section 12) defines
+            # "record = version terms *SP" — the record begins with the version
+            # and only *trailing* spaces are allowed. So a record with leading
+            # whitespace (e.g. " v=spf1 ...") does not begin with the version
+            # section and is discarded rather than treated as valid SPF.
+            cleaned_record = record.strip('"')
             cleaned_record_lower = cleaned_record.lower()
 
             if SENDER_ID_VERSION_TAG_REGEX.match(cleaned_record):

--- a/tests/test_spf.py
+++ b/tests/test_spf.py
@@ -664,6 +664,21 @@ class Test(unittest.TestCase):
         self.assertEqual(result["record"], "v=spf1 -all  ")
 
     @mocked_only
+    def testLeadingWhitespaceSPFRegressionMocked(self):
+        """Regression for issue #258: a record starting with whitespace is invalid
+
+        https://github.com/domainaware/checkdmarc/issues/258 — after PR #255
+        added whitespace stripping, a record such as " v=spf1" was wrongly
+        accepted. RFC 7208 § 4.5 requires a record to *begin* with the exact
+        "v=spf1" version section, so leading whitespace makes it invalid.
+        """
+        for record in (" v=spf1", " v=spf1 -all", "\tv=spf1 -all"):
+            with self.subTest(record=record):
+                with patch("checkdmarc.spf.query_dns", return_value=[record]):
+                    with self.assertRaises(checkdmarc.spf.SPFRecordNotFound):
+                        checkdmarc.spf.query_spf_record("example.com")
+
+    @mocked_only
     def testJunkAfterAllMocked(self):
         """Warn about text after the all mechanism (mocked; ip4 + -all needs no DNS)"""
         rec = "v=spf1 ip4:213.5.39.110 -all MS=83859DAEBD1978F9A7A67D3"

--- a/tests/test_spf.py
+++ b/tests/test_spf.py
@@ -647,12 +647,21 @@ class Test(unittest.TestCase):
         self.assertEqual(result["record"], "V=SPF1 -all")
 
     @mocked_only
-    def testSPFVersionMatchingAllowsSurroundingWhitespaceMocked(self):
-        """SPF records with surrounding whitespace are accepted"""
-        with patch("checkdmarc.spf.query_dns", return_value=["  v=spf1 -all  "]):
+    def testSPFVersionMatchingRejectsLeadingWhitespaceMocked(self):
+        """Records with leading whitespace are discarded (RFC 7208 § 4.5)"""
+        # The record does not *begin* with the "v=spf1" version section, so it
+        # is not a valid SPF record and no SPF record is found.
+        with patch("checkdmarc.spf.query_dns", return_value=["  v=spf1 -all"]):
+            with self.assertRaises(checkdmarc.spf.SPFRecordNotFound):
+                checkdmarc.spf.query_spf_record("example.com")
+
+    @mocked_only
+    def testSPFVersionMatchingAllowsTrailingWhitespaceMocked(self):
+        """Records that begin with v=spf1 but have trailing whitespace are accepted"""
+        with patch("checkdmarc.spf.query_dns", return_value=["v=spf1 -all  "]):
             result = checkdmarc.spf.query_spf_record("example.com")
 
-        self.assertEqual(result["record"], "  v=spf1 -all  ")
+        self.assertEqual(result["record"], "v=spf1 -all  ")
 
     @mocked_only
     def testJunkAfterAllMocked(self):


### PR DESCRIPTION
Fixes #258. Bumps the version to **5.17.2**.

## Problem

PR #255 changed the SPF version check from `record.strip('"')` to `record.strip().strip('"')`. The added `.strip()` removes leading whitespace before the `v=spf1` check, so a TXT record like `" v=spf1 ..."` is now wrongly accepted as a valid SPF record.

## RFC basis

RFC 7208 requires a record to *begin* with the version section:

- **§4.5 (Selecting Records):** "discard records that do not begin with a version section of exactly `v=spf1`. Note that the version section is terminated by either an SP character or the end of the record."
- **ABNF (§12):** `record = version terms *SP` with `version = "v=spf1"` — the record begins with the version, and only *trailing* spaces (`*SP`) are permitted. There is no production for leading whitespace.

So `" v=spf1"` does not begin with the version section and must be discarded; trailing whitespace remains valid.

## Changes

- `checkdmarc/spf.py` — strip only the surrounding quotes, not whitespace, with a comment citing §4.5 and the ABNF.
- `tests/test_spf.py` — replaced the test asserting surrounding whitespace is accepted with tests that reject leading whitespace (`SPFRecordNotFound`) and still accept trailing whitespace, plus a dedicated regression test for issue #258.
- `CHANGELOG.md` — added a 5.17.2 "Fixed" entry.
- `checkdmarc/_constants.py` — bumped version to 5.17.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)