### PR TITLE
ix: replace bare except with logged exception in SPF size check (bandit B110)

### DIFF
--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -542,9 +542,9 @@ def query_spf_record(
                 f"The SPF record for {domain} is {total_bytes} bytes. "
                 "RFC 7208 § 3.4 recommends keeping answers under ~450 bytes so the whole DNS message fits in 512 bytes."
             )
-    except Exception:
+    except Exception as size_check_error:
         # Never let the size check impact normal operation
-        pass
+        logging.debug(f"SPF size check skipped due to error: {size_check_error}")
 
     spf_record = spf_record.replace('"', "")
     results: SPFQueryResults = {"record": spf_record, "warnings": warnings}


### PR DESCRIPTION
Bandit B110 flags the bare `except Exception: pass` at `checkdmarc/spf.py:545`
as silently swallowing all exceptions.

The size check wraps a byte-count warning for deprecated SPF TYPE records
(RFC 7208). The original intent — never interrupt normal operation — is sound,
but the bare `pass` hides unexpected errors from debuggers and log aggregators.

This patch replaces `pass` with `logging.debug(...)` so the exception is
preserved in debug output without changing runtime behaviour.

---
*Generated and verified by [RepoMend](https://github.com/yehorcallmedai-maker/RepoMend)
— local-first security agent. Gate 1 (rescan): pass. Gate 2 (diff in bounds): pass.*