### PR TITLE
Release 5.17.3: narrow the SPF size-check exception (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.17.3
+
+### Changed
+
+- Narrow the advisory SPF record size check to catch only `UnicodeError` (raised when a record can't be encoded to UTF-8) instead of swallowing every exception, and log the skip at debug level
+
 ## 5.17.2
 
 ### Fixed

--- a/checkdmarc/_constants.py
+++ b/checkdmarc/_constants.py
@@ -19,7 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-__version__ = "5.17.2"
+__version__ = "5.17.3"
 
 OS = platform.system()
 OS_RELEASE = platform.release()

--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -542,9 +542,12 @@ def query_spf_record(
                 f"The SPF record for {domain} is {total_bytes} bytes. "
                 "RFC 7208 § 3.4 recommends keeping answers under ~450 bytes so the whole DNS message fits in 512 bytes."
             )
-    except Exception:
-        # Never let the size check impact normal operation
-        pass
+    except UnicodeError as size_check_error:
+        # The size check is advisory only. A record with characters that
+        # can't be encoded to UTF-8 (e.g. a lone surrogate) shouldn't break
+        # the lookup, so skip the byte-size warnings for it. Any other error
+        # here is unexpected and should surface rather than be swallowed.
+        logging.debug(f"Skipped SPF size check for {domain}: {size_check_error}")
 
     spf_record = spf_record.replace('"', "")
     results: SPFQueryResults = {"record": spf_record, "warnings": warnings}

--- a/tests/test_spf.py
+++ b/tests/test_spf.py
@@ -1123,6 +1123,23 @@ class TestSPFQueryRecordEdges(unittest.TestCase):
             result = checkdmarc.spf.query_spf_record("example.com")
         self.assertTrue(any("> 512 bytes" in w for w in result["warnings"]))
 
+    def testSizeCheckSkippedOnUndecodableRecord(self):
+        """A record that can't be UTF-8 encoded skips the advisory size check"""
+        # A lone surrogate cannot be encoded to UTF-8, so the byte-size check
+        # raises UnicodeError. That must be swallowed (the check is advisory)
+        # without breaking the overall lookup or emitting a size warning.
+        record = "v=spf1 \ud800 -all"
+
+        def fake_query_dns(domain, rdtype, **kwargs):
+            if rdtype == "SPF":
+                return []
+            return [record]
+
+        with patch("checkdmarc.spf.query_dns", side_effect=fake_query_dns):
+            result = checkdmarc.spf.query_spf_record("example.com")
+        self.assertEqual(result["record"], record)
+        self.assertFalse(any("bytes" in w for w in result["warnings"]))
+
 
 class TestSPFCheckSpfErrorData(unittest.TestCase):
     def testErrorWithDataKeysIncluded(self):


### PR DESCRIPTION
The advisory SPF record size check in `query_spf_record` ends with:

```python
except Exception:
    # Never let the size check impact normal operation
    pass
```

Bandit flags this as **B110** (`try_except_pass`), and it also conflicts with the project rule in AGENTS.md: *"Don't catch `Exception` broadly. Catch only the specific exception types you have a recovery path for."* A bare `except Exception: pass` hides programming errors and disguises broken assumptions as transient failures.

## Change

By the time the size check runs, `spf_record` is guaranteed to be a non-`None` `str`. The only failure the block can legitimately recover from is a `UnicodeError` raised by `.encode("utf-8")` when the record contains characters that can't be encoded to UTF-8 (e.g. a lone surrogate). Anything else is unexpected and should surface rather than be swallowed.

- Narrow the catch to `except UnicodeError`.
- Log at `debug` instead of silently passing (so the skip is observable).
- Add a test that feeds a record containing a lone surrogate, forcing the `UnicodeError` path, and asserts the lookup still returns the record with no size warning. The test passing (rather than erroring) proves the branch is actually taken — an uncaught `UnicodeEncodeError` would otherwise propagate out of `query_spf_record`.

## Why only `UnicodeError`?

Going operation-by-operation through the block, given `spf_record` is a guaranteed non-`None` `str`:

| Operation | Can it raise here? |
|---|---|
| `re.findall(r'"([^"]*)"', spf_record)` | **No.** `re.error` is raised only when *compiling* an invalid pattern; this pattern is a constant, valid literal. On a `str` subject `findall` does not raise (verified on empty, ASCII, surrogate, and 100k-char inputs), and the pattern is linear so there is no catastrophic-backtracking risk. |
| `chunk.encode("utf-8")` / `joined.encode("utf-8")` | **Yes — `UnicodeError`** (`UnicodeEncodeError`) on un-encodable content such as a lone surrogate. |
| `"".join(...)`, `.replace()`, `len()`, `enumerate()` | No — operations over `str`/`list`. |

So `re.error` and `TypeError` cannot occur here: `re.error` only fires at compile time, and a `TypeError` would require `spf_record` to be a non-`str`, which violates the precondition established earlier in the function (`if spf_record is None: raise ...` plus the version-matching path). If that invariant were ever broken, AGENTS.md wants it to be **loud**, not swallowed by an advisory size check. Widening the catch back to a tuple of hypotheticals would re-introduce exactly the "catch things you have no recovery path for" problem this change fixes.

Full `test_spf.py` suite passes; ruff clean.

## Relationship to #261

This supersedes #261, which addressed the same Bandit B110 finding but kept the broad `except Exception` and only swapped `pass` for a debug log. This PR additionally narrows the exception type to satisfy the AGENTS.md convention, so #261 can be closed in favor of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)