### PR TITLE
Narrow broad except handlers across the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Narrow the advisory SPF record size check to catch only `UnicodeError` (raised when a record can't be encoded to UTF-8) instead of swallowing every exception, and log the skip at debug level
+- Replace the remaining broad `except Exception` handlers across the package with the specific exception types each block can recover from, so unexpected programming errors surface instead of being masked. As a result, intentional record-validation errors (e.g. `MultipleSPFRTXTRecords`, `MTASTSRecordInWrongLocation`) now propagate as their own types rather than being converted to a generic "record not found" error
 
 ## 5.17.2
 

--- a/checkdmarc/bimi.py
+++ b/checkdmarc/bimi.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from sys import getsizeof
 from typing import Optional, Union, TypedDict, Any
+from xml.parsers.expat import ExpatError
 
 try:
     from importlib.resources import files
@@ -523,7 +524,7 @@ def get_svg_metadata(raw_xml: Union[str, bytes]) -> dict[str, Any]:
             raw_xml.encode("utf-8")  # pyright: ignore[reportAttributeAccessIssue]
         ).hexdigest()  # pyright: ignore[reportAttributeAccessIssue]
         return metadata
-    except Exception as e:
+    except (ExpatError, KeyError, ValueError, IndexError, TypeError) as e:
         raise ValueError(f"Not a SVG file: {str(e)}")
 
 
@@ -798,7 +799,7 @@ def get_certificate_metadata(pem_crt: bytes, *, domain=None) -> dict[str, Any]:
             metadata["logotype_sha256"] = hashlib.sha256(logotype).hexdigest()
         metadata["warnings"] = warnings
         metadata["validation_errors"] = validation_errors
-    except Exception as e:
+    except (KeyError, ValueError, IndexError, AttributeError) as e:
         validation_errors.append(str(e))
         metadata["valid"] = False
         metadata["validation_errors"] = validation_errors
@@ -885,7 +886,7 @@ def _query_bimi_record(
             # Let BIMI-specific exceptions (BIMIRecordInWrongLocation) propagate
             # — they were being silently swallowed because `raise` was missing.
             raise
-        except Exception as error:
+        except dns.exception.DNSException as error:
             raise BIMIRecordNotFound(error)
 
     except dns.resolver.NXDOMAIN:
@@ -896,7 +897,7 @@ def _query_bimi_record(
         # type instead of catching the broad BIMIRecordNotFound this clause
         # used to convert everything to.
         raise
-    except Exception as error:
+    except dns.exception.DNSException as error:
         raise BIMIRecordNotFound(error)
 
     return bimi_record
@@ -1102,7 +1103,7 @@ def parse_bimi_record(
                 response = session.get(tag_value, timeout=http_timeout)
                 response.raise_for_status()
                 raw_xml = response.content
-            except Exception as e:
+            except requests.RequestException as e:
                 results["image"] = {
                     "error": f"Failed to download BIMI image at {tag_value} - {str(e)}"
                 }
@@ -1125,7 +1126,7 @@ def parse_bimi_record(
                     svg_validation_errors = check_svg_requirements(svg_metadata)
                     if len(svg_validation_errors) > 0:
                         svg_metadata["validation_errors"] = svg_validation_errors
-                except Exception as e:
+                except (ValueError, KeyError) as e:
                     results["image"] = {
                         "error": f"Failed to process BIMI image at {tag_value} - {str(e)}"
                     }
@@ -1143,7 +1144,7 @@ def parse_bimi_record(
                         warnings.append(
                             "The image at the l= tag URL does not match the image embedded in the certificate."
                         )
-            except Exception as e:
+            except (requests.RequestException, ValueError, KeyError) as e:
                 results["certificate"] = {
                     "error": f"Failed to download the mark certificate at {tag_value} - {str(e)}"
                 }

--- a/checkdmarc/dmarc.py
+++ b/checkdmarc/dmarc.py
@@ -752,7 +752,7 @@ def _query_dmarc_record(
             # above — propagate it instead of letting the broad ``except``
             # below convert it to DMARCRecordNotFound.
             raise
-        except Exception as error:
+        except dns.exception.DNSException as error:
             raise DMARCRecordNotFound(error)
 
     except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
@@ -763,7 +763,7 @@ def _query_dmarc_record(
         raise error
     except MultipleDMARCRecords as error:
         raise error
-    except Exception as error:
+    except dns.exception.DNSException as error:
         raise DMARCError(str(error))
 
     return dmarc_record
@@ -1125,7 +1125,9 @@ def verify_dmarc_report_destination(
 
             if dmarc_record_count < 1:
                 raise UnverifiedDMARCURIDestination(message)
-        except Exception:
+        except (dns.exception.DNSException, UnrelatedTXTRecordFoundAtDMARC):
+            # A DNS failure or unrelated TXT records at the authorization
+            # location both mean the destination can't be confirmed.
             raise UnverifiedDMARCURIDestination(message)
 
 

--- a/checkdmarc/mta_sts.py
+++ b/checkdmarc/mta_sts.py
@@ -294,9 +294,9 @@ def query_mta_sts_record(
             pass
         except dns.resolver.NXDOMAIN:
             raise MTASTSRecordNotFound("The domain does not exist.")
-        except Exception as error:
+        except dns.exception.DNSException as error:
             raise MTASTSRecordNotFound(error)
-    except Exception as error:
+    except dns.exception.DNSException as error:
         raise MTASTSRecordNotFound(error)
 
     if sts_record is None:
@@ -442,7 +442,7 @@ def download_mta_sts_policy(
                 f"be set to {expected_content_type}"
             )
 
-    except Exception as e:
+    except requests.RequestException as e:
         raise MTASTSPolicyDownloadError(str(e))
 
     results: DownloadedMTASTSPolicy = {"policy": response.text, "warnings": warnings}

--- a/checkdmarc/smtp.py
+++ b/checkdmarc/smtp.py
@@ -11,6 +11,7 @@ import ssl
 from typing import TypedDict, Optional, Union
 from collections.abc import Sequence
 
+import dns.exception
 import dns.resolver
 from dns.nameserver import Nameserver
 
@@ -179,11 +180,6 @@ def test_tls(
         if cache is not None:
             cache[hostname] = {"tls": False, "error": error}
         raise SMTPError(error)
-    except Exception as e:
-        error = e.__str__()
-        if cache is not None:
-            cache[hostname] = {"tls": False, "error": error}
-        raise SMTPError(error)
 
 
 def test_starttls(
@@ -294,11 +290,6 @@ def test_starttls(
         if cache is not None:
             cache[hostname] = {"starttls": False, "error": error}
         raise SMTPError(error)
-    except Exception as e:
-        error = e.__str__()
-        if cache is not None:
-            cache[hostname] = {"starttls": False, "error": error}
-        raise SMTPError(error)
 
 
 def get_mx_hosts(
@@ -392,7 +383,7 @@ def get_mx_hosts(
                     nameservers=nameservers,
                     timeout=timeout,
                 )
-            except Exception as e:
+            except (dns.exception.DNSException, OSError, EOFError) as e:
                 logging.debug(e)
             host["dnssec"] = dnssec
             host["addresses"] = []
@@ -413,7 +404,7 @@ def get_mx_hosts(
                 host["tlsa"] = tlsa_records
             if len(host["addresses"]) == 0:
                 warnings.append(f"{hostname} does not have any A or AAAA DNS records.")
-        except Exception as e:
+        except (DNSException, ValueError) as e:
             if hostname.lower().endswith(".msv1.invalid"):
                 warnings.append(
                     f"{e}. Consider using a TXT record to "

--- a/checkdmarc/smtp_tls_reporting.py
+++ b/checkdmarc/smtp_tls_reporting.py
@@ -269,9 +269,9 @@ def query_smtp_tls_reporting_record(
             pass
         except dns.resolver.NXDOMAIN:
             raise SMTPTLSReportingRecordNotFound("The domain does not exist.")
-        except Exception as error:
+        except dns.exception.DNSException as error:
             raise SMTPTLSReportingRecordNotFound(error)
-    except Exception as error:
+    except dns.exception.DNSException as error:
         raise SMTPTLSReportingRecordNotFound(error)
 
     if sts_record is None:

--- a/checkdmarc/soa.py
+++ b/checkdmarc/soa.py
@@ -8,7 +8,7 @@ import dns.resolver
 from dns.nameserver import Nameserver
 
 from checkdmarc._constants import DEFAULT_DNS_TIMEOUT, DEFAULT_DNS_MAX_RETRIES
-from checkdmarc.utils import get_soa_record
+from checkdmarc.utils import DNSException, get_soa_record
 
 """Functions for parsing DNS Start of Authority records"""
 
@@ -130,7 +130,7 @@ def check_soa(
             retries=retries,
         )
 
-    except Exception as e:
+    except DNSException as e:
         failure_results: SOARecordError = {"record": None, "error": str(e)}
         return failure_results
     try:
@@ -139,6 +139,6 @@ def check_soa(
             "values": parse_soa_string(record),
         }
         return results
-    except Exception as e:
+    except ValueError as e:
         failure_results: SOARecordError = {"record": record, "error": str(e)}
         return failure_results

--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -505,7 +505,7 @@ def query_spf_record(
         raise SPFRecordNotFound("The domain does not exist.", domain)
     except SPFRecordNotFound as error:
         raise error
-    except Exception as error:
+    except dns.exception.DNSException as error:
         raise SPFRecordNotFound(error, domain)
 
     # Per RFC 7208 § 3.3: any single TXT "character-string" should be ≤255 characters.
@@ -710,7 +710,7 @@ def parse_spf_record(
                         warnings.append(f"No TXT records at exp value {exp}.")
                     if len(exp_txt_records) > 1:
                         warnings.append(f"Too many TXT records at exp value {exp}.")
-                except Exception as e:
+                except DNSException as e:
                     warnings.append(
                         f"Failed to get TXT records at exp value {exp}: {e}"
                     )
@@ -1040,7 +1040,7 @@ def parse_spf_record(
                             warnings.append(f"No TXT records at exp value {exp}.")
                         if len(exp_txt_records) > 1:
                             warnings.append(f"Too many TXT records at exp value {exp}.")
-                    except Exception as e:
+                    except DNSException as e:
                         warnings.append(
                             f"Failed to get TXT records at exp value {exp}: {e}"
                         )

--- a/checkdmarc/utils.py
+++ b/checkdmarc/utils.py
@@ -315,7 +315,7 @@ def get_a_records(
         except dns.resolver.NoAnswer:
             # Sometimes a domain will only have A or AAAA records, but not both
             pass
-        except Exception as error:
+        except dns.exception.DNSException as error:
             raise DNSException(error)
 
     addresses = sorted(addresses)
@@ -361,7 +361,7 @@ def get_reverse_dns(
         )
     except dns.resolver.NXDOMAIN:
         return []
-    except Exception as error:
+    except dns.exception.DNSException as error:
         raise DNSException(error)
 
     return hostnames
@@ -409,7 +409,7 @@ def get_txt_records(
         raise DNSExceptionNXDOMAIN(f"The domain {domain} does not exist.")
     except dns.resolver.NoAnswer:
         raise DNSException(f"The domain {domain} does not have any TXT records.")
-    except Exception as error:
+    except dns.exception.DNSException as error:
         raise DNSException(error)
 
     return records
@@ -455,7 +455,7 @@ def get_soa_record(
         raise DNSExceptionNXDOMAIN(f"The domain {domain} does not exist.")
     except dns.resolver.NoAnswer:
         raise DNSException(f"The domain {domain} does not have an SOA record.")
-    except Exception as error:
+    except dns.exception.DNSException as error:
         raise DNSException(error)
 
     return record
@@ -504,7 +504,7 @@ def get_nameservers(
         raise DNSExceptionNXDOMAIN(f"The domain {domain} does not exist.")
     except dns.resolver.NoAnswer:
         pass
-    except Exception as error:
+    except dns.exception.DNSException as error:
         raise DNSException(error)
 
     if approved_nameservers:
@@ -574,6 +574,6 @@ def get_mx_records(
         raise DNSExceptionNXDOMAIN(f"The domain {domain} does not exist.")
     except dns.resolver.NoAnswer:
         pass
-    except Exception as error:
+    except dns.exception.DNSException as error:
         raise DNSException(error)
     return hosts

--- a/tests/test_bimi.py
+++ b/tests/test_bimi.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 import dns.exception
 import dns.resolver
+import requests
 
 import checkdmarc.bimi
 
@@ -166,13 +167,25 @@ class TestQueryBimiRecordPropagatesSpecificErrors(unittest.TestCase):
                 "example.com",
             )
 
-    def testGenericExceptionStillConvertsToNotFound(self):
-        """Non-BIMI exceptions are still wrapped as BIMIRecordNotFound"""
+    def testDNSExceptionConvertsToNotFound(self):
+        """A DNS-layer error is wrapped as BIMIRecordNotFound"""
+        with patch(
+            "checkdmarc.bimi.query_dns",
+            side_effect=dns.exception.DNSException("network down"),
+        ):
+            self.assertRaises(
+                checkdmarc.bimi.BIMIRecordNotFound,
+                checkdmarc.bimi._query_bimi_record,
+                "example.com",
+            )
+
+    def testNonDNSExceptionPropagates(self):
+        """A non-DNS error (e.g. a programming bug) is not masked as BIMIRecordNotFound"""
         with patch(
             "checkdmarc.bimi.query_dns", side_effect=RuntimeError("network down")
         ):
             self.assertRaises(
-                checkdmarc.bimi.BIMIRecordNotFound,
+                RuntimeError,
                 checkdmarc.bimi._query_bimi_record,
                 "example.com",
             )
@@ -187,7 +200,7 @@ class TestQueryBimiRecordPropagatesSpecificErrors(unittest.TestCase):
         def fake_query_dns(target, rdtype, **kwargs):
             if target == "default._bimi.example.com":
                 raise dns.resolver.NoAnswer()
-            raise RuntimeError("network down")
+            raise dns.exception.DNSException("network down")
 
         with patch("checkdmarc.bimi.query_dns", side_effect=fake_query_dns):
             self.assertRaises(
@@ -332,7 +345,7 @@ class TestParseBimiRecord(unittest.TestCase):
         """A failed l= fetch produces an image error entry, not a raised exception"""
         fake_session = MagicMock()
         fake_session.get.return_value = _fake_response(
-            b"", raise_for_status_exc=Exception("404 Not Found")
+            b"", raise_for_status_exc=requests.exceptions.HTTPError("404 Not Found")
         )
         with patch("checkdmarc.bimi.requests.Session", return_value=fake_session):
             result = checkdmarc.bimi.parse_bimi_record(
@@ -344,7 +357,8 @@ class TestParseBimiRecord(unittest.TestCase):
         """A failed a= fetch produces a certificate error entry"""
         fake_session = MagicMock()
         fake_session.get.return_value = _fake_response(
-            b"", raise_for_status_exc=Exception("connection refused")
+            b"",
+            raise_for_status_exc=requests.exceptions.HTTPError("connection refused"),
         )
         with patch("checkdmarc.bimi.requests.Session", return_value=fake_session):
             result = checkdmarc.bimi.parse_bimi_record(

--- a/tests/test_dmarc.py
+++ b/tests/test_dmarc.py
@@ -4,6 +4,7 @@ import unittest
 from typing import Any, cast
 from unittest.mock import patch
 
+import dns.exception
 import dns.resolver
 
 import checkdmarc.dmarc
@@ -614,13 +615,13 @@ class TestQueryDmarcRecordEdges(unittest.TestCase):
                 "example.com",
             )
 
-    def testApexFallbackGenericException(self):
-        """NoAnswer at _dmarc, then a generic Exception at apex raises DMARCRecordNotFound"""
+    def testApexFallbackDNSException(self):
+        """NoAnswer at _dmarc, then a DNS error at apex raises DMARCRecordNotFound"""
 
         def fake_query_dns(target, rdtype, **kwargs):
             if target.startswith("_dmarc."):
                 raise dns.resolver.NoAnswer()
-            raise RuntimeError("oops")
+            raise dns.exception.DNSException("dns down")
 
         with patch("checkdmarc.dmarc.query_dns", side_effect=fake_query_dns):
             self.assertRaises(
@@ -629,12 +630,25 @@ class TestQueryDmarcRecordEdges(unittest.TestCase):
                 "example.com",
             )
 
-    def testGenericExceptionAtSelectorWraps(self):
-        """A non-DNS, non-DMARC exception at the selector wraps as DMARCError"""
+    def testDNSExceptionAtSelectorWraps(self):
+        """A DNS error at the selector wraps as DMARCError"""
+
+        with patch(
+            "checkdmarc.dmarc.query_dns",
+            side_effect=dns.exception.DNSException("dns down"),
+        ):
+            self.assertRaises(
+                checkdmarc.dmarc.DMARCError,
+                checkdmarc.dmarc._query_dmarc_record,
+                "example.com",
+            )
+
+    def testNonDNSExceptionAtSelectorPropagates(self):
+        """A non-DNS error (e.g. a programming bug) at the selector is not masked"""
 
         with patch("checkdmarc.dmarc.query_dns", side_effect=RuntimeError("oops")):
             self.assertRaises(
-                checkdmarc.dmarc.DMARCError,
+                RuntimeError,
                 checkdmarc.dmarc._query_dmarc_record,
                 "example.com",
             )

--- a/tests/test_mta_sts.py
+++ b/tests/test_mta_sts.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, cast
 from unittest.mock import MagicMock, patch
 
 import dns.resolver
+import requests
 
 import checkdmarc.mta_sts
 
@@ -270,7 +271,9 @@ class TestDownloadMtaStsPolicy(unittest.TestCase):
     def testHttpFailureRaises(self):
         with patch(
             "checkdmarc.mta_sts.requests.Session",
-            return_value=self._make_session(raise_exc=Exception("HTTP 404")),
+            return_value=self._make_session(
+                raise_exc=requests.exceptions.HTTPError("HTTP 404")
+            ),
         ):
             self.assertRaises(
                 checkdmarc.mta_sts.MTASTSPolicyDownloadError,

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -12,6 +12,7 @@ import unittest
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
+import dns.exception
 from expiringdict import ExpiringDict
 
 import checkdmarc.smtp
@@ -137,11 +138,13 @@ class TestTestTLS(unittest.TestCase):
                 "mail.example.com",
             )
 
-    def testGenericException(self):
-        """Unanticipated exceptions still surface as SMTPError"""
+    def testUnexpectedExceptionPropagates(self):
+        """An unexpected (non-network) exception is not masked as SMTPError"""
+        # Connection/SMTP failures are handled and surfaced as SMTPError; a
+        # programming-error type should propagate so the bug stays visible.
         with patch("smtplib.SMTP_SSL", side_effect=RuntimeError("oops")):
             self.assertRaises(
-                checkdmarc.smtp.SMTPError,
+                RuntimeError,
                 checkdmarc.smtp.test_tls,
                 "mail.example.com",
             )
@@ -574,9 +577,6 @@ class TestTLSCacheWritesOnError(unittest.TestCase):
     def testOSErrorCached(self):
         self._run_and_check_cache(OSError("Network unreachable"))
 
-    def testGenericExceptionCached(self):
-        self._run_and_check_cache(RuntimeError("oops"))
-
 
 class TestSTARTTLSCacheAndExtraBranches(unittest.TestCase):
     """test_starttls cache-on-error coverage and remaining exception handlers"""
@@ -626,9 +626,6 @@ class TestSTARTTLSCacheAndExtraBranches(unittest.TestCase):
     def testOSErrorCached(self):
         self._run_and_check_cache(OSError("Network unreachable"))
 
-    def testGenericExceptionCached(self):
-        self._run_and_check_cache(RuntimeError("oops"))
-
 
 class TestGetMxHostsEdgeCases(unittest.TestCase):
     """Branches of get_mx_hosts not covered by TestGetMxHosts"""
@@ -649,7 +646,10 @@ class TestGetMxHostsEdgeCases(unittest.TestCase):
                 )
             )
             stack.enter_context(
-                patch("checkdmarc.smtp.test_dnssec", side_effect=RuntimeError("oops"))
+                patch(
+                    "checkdmarc.smtp.test_dnssec",
+                    side_effect=dns.exception.DNSException("dnssec failed"),
+                )
             )
             stack.enter_context(
                 patch("checkdmarc.smtp.get_a_records", return_value=["192.0.2.1"])

--- a/tests/test_soa.py
+++ b/tests/test_soa.py
@@ -66,9 +66,9 @@ class Test(unittest.TestCase):
             )
 
     def testCheckSoaError(self):
-        """check_soa returns error on failure"""
+        """check_soa returns error on a DNS lookup failure"""
         with patch("checkdmarc.soa.get_soa_record") as mock_soa:
-            mock_soa.side_effect = Exception("DNS error")
+            mock_soa.side_effect = checkdmarc.soa.DNSException("DNS error")
             result = checkdmarc.soa.check_soa("example.com")
             self.assertIn("error", result)
 

--- a/tests/test_spf.py
+++ b/tests/test_spf.py
@@ -5,6 +5,8 @@ import unittest
 from unittest.mock import patch
 from typing import Any, cast
 
+import dns.exception
+
 import checkdmarc.spf
 from checkdmarc.spf import ParsedSPFMXMechanism, SPFAMechanism
 
@@ -458,17 +460,20 @@ class Test(unittest.TestCase):
         # Mock query_dns to return:
         # 1. An undecodable non-SPF TXT record
         # 2. A valid SPF record
-        with patch("checkdmarc.spf.query_dns") as mock_query_dns:
-            # First call for SPF type records (returns empty)
-            # Second call for TXT records (returns undecodable + valid SPF)
-            mock_query_dns.side_effect = [
-                [],  # No SPF type records
-                [
+        def fake_query_dns(name, rdtype, **kwargs):
+            if rdtype == "SPF":
+                return []  # No SPF type records
+            if name == domain:
+                return [
                     "Undecodable characters",  # TXT record with undecodable chars
                     '"v=spf1 include:spf.smtp2go.com -all"',  # Valid SPF record
-                ],
-            ]
+                ]
+            # The valid record includes spf.smtp2go.com; return no record for it
+            # so include resolution produces a warning rather than exhausting the
+            # mock. The behavior under test is the undecodable-record handling.
+            return []
 
+        with patch("checkdmarc.spf.query_dns", side_effect=fake_query_dns):
             # This should succeed and return the valid SPF record
             result = checkdmarc.spf.get_spf_record(domain)
 
@@ -939,7 +944,7 @@ class TestSPFExpModifier(unittest.TestCase):
     def testExpAfterAllExceptionWarning(self):
         with patch(
             "checkdmarc.spf.get_txt_records",
-            side_effect=RuntimeError("dns broken"),
+            side_effect=checkdmarc.spf.DNSException("dns broken"),
         ):
             result = checkdmarc.spf.parse_spf_record(
                 "v=spf1 -all exp=exp.example", "example.com"
@@ -1081,8 +1086,23 @@ class TestSPFQueryRecordEdges(unittest.TestCase):
                 "example.com",
             )
 
-    def testGenericExceptionReraises(self):
-        """A non-SPF, non-DNS exception during TXT lookup also becomes SPFRecordNotFound"""
+    def testDNSExceptionBecomesSPFRecordNotFound(self):
+        """A DNS-layer error during the TXT lookup is normalized to SPFRecordNotFound"""
+
+        def fake_query_dns(domain, rdtype, **kwargs):
+            if rdtype == "SPF":
+                return []
+            raise dns.exception.DNSException("dns down")
+
+        with patch("checkdmarc.spf.query_dns", side_effect=fake_query_dns):
+            self.assertRaises(
+                checkdmarc.spf.SPFRecordNotFound,
+                checkdmarc.spf.query_spf_record,
+                "example.com",
+            )
+
+    def testNonDNSExceptionPropagates(self):
+        """A non-DNS error (e.g. a programming bug) during the TXT lookup is not masked"""
 
         def fake_query_dns(domain, rdtype, **kwargs):
             if rdtype == "SPF":
@@ -1091,7 +1111,7 @@ class TestSPFQueryRecordEdges(unittest.TestCase):
 
         with patch("checkdmarc.spf.query_dns", side_effect=fake_query_dns):
             self.assertRaises(
-                checkdmarc.spf.SPFRecordNotFound,
+                RuntimeError,
                 checkdmarc.spf.query_spf_record,
                 "example.com",
             )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import dns.exception
 import dns.resolver
 from expiringdict import ExpiringDict
 
@@ -245,8 +246,11 @@ class TestGetReverseDns(unittest.TestCase):
         self.assertEqual(result, [])
 
     def testReverseOtherErrorRaises(self):
-        """A generic exception is wrapped in DNSException"""
-        with patch("checkdmarc.utils.query_dns", side_effect=RuntimeError("boom")):
+        """A DNS-layer error is wrapped in DNSException"""
+        with patch(
+            "checkdmarc.utils.query_dns",
+            side_effect=dns.exception.DNSException("DNS lookup failed"),
+        ):
             self.assertRaises(
                 checkdmarc.utils.DNSException,
                 checkdmarc.utils.get_reverse_dns,
@@ -277,9 +281,23 @@ class TestGetTxtRecords(unittest.TestCase):
             )
 
     def testGenericError(self):
-        with patch("checkdmarc.utils.query_dns", side_effect=RuntimeError("boom")):
+        with patch(
+            "checkdmarc.utils.query_dns",
+            side_effect=dns.exception.DNSException("DNS lookup failed"),
+        ):
             self.assertRaises(
                 checkdmarc.utils.DNSException,
+                checkdmarc.utils.get_txt_records,
+                "example.com",
+            )
+
+    def testNonDNSErrorPropagates(self):
+        """A non-DNS error (e.g. a programming bug) is not swallowed as DNSException"""
+        # The DNS wrappers normalize DNS-layer failures to DNSException, but an
+        # unexpected error type must surface instead of being hidden.
+        with patch("checkdmarc.utils.query_dns", side_effect=KeyError("bug")):
+            self.assertRaises(
+                KeyError,
                 checkdmarc.utils.get_txt_records,
                 "example.com",
             )
@@ -313,7 +331,10 @@ class TestGetSoaRecord(unittest.TestCase):
             )
 
     def testGenericError(self):
-        with patch("checkdmarc.utils.query_dns", side_effect=RuntimeError("boom")):
+        with patch(
+            "checkdmarc.utils.query_dns",
+            side_effect=dns.exception.DNSException("DNS lookup failed"),
+        ):
             self.assertRaises(
                 checkdmarc.utils.DNSException,
                 checkdmarc.utils.get_soa_record,
@@ -357,7 +378,10 @@ class TestGetNameservers(unittest.TestCase):
         self.assertEqual(result["hostnames"], [])
 
     def testGenericError(self):
-        with patch("checkdmarc.utils.query_dns", side_effect=RuntimeError("boom")):
+        with patch(
+            "checkdmarc.utils.query_dns",
+            side_effect=dns.exception.DNSException("DNS lookup failed"),
+        ):
             self.assertRaises(
                 checkdmarc.utils.DNSException,
                 checkdmarc.utils.get_nameservers,
@@ -393,7 +417,10 @@ class TestGetARecords(unittest.TestCase):
         self.assertEqual(result, ["2001:db8::1"])
 
     def testGenericError(self):
-        with patch("checkdmarc.utils.query_dns", side_effect=RuntimeError("boom")):
+        with patch(
+            "checkdmarc.utils.query_dns",
+            side_effect=dns.exception.DNSException("DNS lookup failed"),
+        ):
             self.assertRaises(
                 checkdmarc.utils.DNSException,
                 checkdmarc.utils.get_a_records,
@@ -433,7 +460,10 @@ class TestGetMxRecords(unittest.TestCase):
         self.assertEqual(result, [])
 
     def testGenericError(self):
-        with patch("checkdmarc.utils.query_dns", side_effect=RuntimeError("boom")):
+        with patch(
+            "checkdmarc.utils.query_dns",
+            side_effect=dns.exception.DNSException("DNS lookup failed"),
+        ):
             self.assertRaises(
                 checkdmarc.utils.DNSException,
                 checkdmarc.utils.get_mx_records,


### PR DESCRIPTION
Follows up the SPF size-check fix (#262) by applying the same treatment to **every remaining broad `except Exception`** in the package, per the AGENTS.md rule: *"Catch only the specific exception types you have a recovery path for."*

## What changed

30 broad handlers across 8 modules were narrowed to the types each block can actually recover from:

| Module | Sites | Narrowed to |
|--------|-------|-------------|
| `utils.py` | 6 | `dns.exception.DNSException` (DNS query wrappers) |
| `soa.py` | 2 | `DNSException` (lookup) / `ValueError` (parse) |
| `spf.py` | 3 | `dns.exception.DNSException` / `DNSException` |
| `dmarc.py` | 3 | `dns.exception.DNSException` (+ `UnrelatedTXTRecordFoundAtDMARC` where intended) |
| `mta_sts.py` | 3 | `dns.exception.DNSException` / `requests.RequestException` |
| `smtp_tls_reporting.py` | 2 | `dns.exception.DNSException` |
| `smtp.py` | 4 | removed 2 redundant catch-alls (OSError + SMTPException already cover them); narrowed dnssec/DNS helpers |
| `bimi.py` | 7 | `dns.exception.DNSException` / `requests.RequestException` / parser types (`ExpatError`, `ValueError`, `KeyError`, ...) |

After this change, `grep -rn "except Exception" checkdmarc/` returns nothing.

## Behavior change worth noting

Some intentional, typed record-validation errors were being *flattened* by the broad catch (e.g. `MultipleSPFRTXTRecords` → `SPFRecordNotFound`, `MTASTSRecordInWrongLocation` → `MTASTSRecordNotFound`). They now propagate as their own types. Programming errors (e.g. a stray `RuntimeError`) now surface instead of being disguised as a domain "not found" error.

## Tests

Tests that previously triggered the broad catch with a synthetic non-DNS exception (`RuntimeError`, bare `Exception`) are updated to trigger the **realistic** error type (a `dns.exception.DNSException`, `requests.HTTPError`, etc.) and, where useful, a companion test asserts that an unexpected error now propagates rather than being masked. Two obsolete tests that only existed to cover a removed catch-all were dropped (the real-error caching path is already covered by `testOSErrorCached`).

- Full suite: **444 passed, 11 skipped**
- Coverage: **96%** (unchanged)
- `ruff` clean, `pyright` 0 errors

Rides in the unreleased 5.17.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)