### PR TITLE
Modernize type annotations (PEP 604) and fix requires-python declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Narrow the advisory SPF record size check to catch only `UnicodeError` (raised when a record can't be encoded to UTF-8) instead of swallowing every exception, and log the skip at debug level
 - Replace the remaining broad `except Exception` handlers across the package with the specific exception types each block can recover from, so unexpected programming errors surface instead of being masked. As a result, intentional record-validation errors (e.g. `MultipleSPFRTXTRecords`, `MTASTSRecordInWrongLocation`) now propagate as their own types rather than being converted to a generic "record not found" error
+- Modernize type annotations to PEP 604 syntax (`X | None` and `X | Y` instead of `Optional[X]` and `Union[X, Y]`) throughout the package
+
+### Fixed
+
+- Declare the supported Python floor with the correct `requires-python` key (the previous `python_requires` key is not recognized in a PEP 621 `[project]` table, so the published metadata advertised no minimum and pip would install on end-of-life Python versions where the modern type-alias syntax fails). Also add per-version Python classifiers for 3.10–3.14
 
 ## 5.17.2
 

--- a/checkdmarc/__init__.py
+++ b/checkdmarc/__init__.py
@@ -9,7 +9,7 @@ import logging
 from csv import DictWriter
 from io import StringIO
 from time import sleep
-from typing import Optional, TypedDict, Union
+from typing import TypedDict
 from collections.abc import Sequence
 
 import dns.resolver
@@ -76,7 +76,7 @@ class DomainCheckResult(_DomainCheckResultOptional):
     ns: NameserverResult
     mx: MXResults
     spf: SPFRecordResults
-    dmarc: Union[DMARCResults, DMARCErrorResults]
+    dmarc: DMARCResults | DMARCErrorResults
     smtp_tls_reporting: SMTPTLSReportingResults
     mta_sts: MTASTSCheckResults
 
@@ -85,17 +85,17 @@ def check_domains(
     domains: list[str],
     *,
     parked: bool = False,
-    approved_nameservers: Optional[Sequence[str | Nameserver]] = None,
-    approved_mx_hostnames: Optional[list[str]] = None,
+    approved_nameservers: Sequence[str | Nameserver] | None = None,
+    approved_mx_hostnames: list[str] | None = None,
     skip_tls: bool = False,
     bimi_selector: str = "default",
     include_tag_descriptions: bool = False,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
     wait: float = 0.0,
-) -> Union[DomainCheckResult, list[DomainCheckResult]]:
+) -> DomainCheckResult | list[DomainCheckResult]:
     """
     Check the given domains for SPF and DMARC records, parse them, and return
     them
@@ -256,9 +256,9 @@ def check_domains(
 def check_ns(
     domain: str,
     *,
-    approved_nameservers: Optional[Sequence[str | Nameserver]] = None,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    approved_nameservers: Sequence[str | Nameserver] | None = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> NameserverResult:
@@ -304,7 +304,7 @@ def check_ns(
 
 
 def results_to_json(
-    results: Union[DomainCheckResult, list[DomainCheckResult]],
+    results: DomainCheckResult | list[DomainCheckResult],
 ) -> str:
     """
     Converts a dictionary of results or list of results to a JSON string
@@ -319,7 +319,7 @@ def results_to_json(
 
 
 def results_to_csv_rows(
-    results: Union[DomainCheckResult, list[DomainCheckResult]],
+    results: DomainCheckResult | list[DomainCheckResult],
 ) -> list[dict]:
     """
     Converts a results dictionary or list of dictionaries and returns a
@@ -458,7 +458,7 @@ def results_to_csv_rows(
 
 
 def results_to_csv(
-    results: Union[DomainCheckResult, list[DomainCheckResult]],
+    results: DomainCheckResult | list[DomainCheckResult],
 ) -> str:
     """
     Converts a dictionary of results to CSV

--- a/checkdmarc/bimi.py
+++ b/checkdmarc/bimi.py
@@ -11,7 +11,7 @@ import re
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from sys import getsizeof
-from typing import Optional, Union, TypedDict, Any
+from typing import TypedDict, Any
 from xml.parsers.expat import ExpatError
 
 try:
@@ -105,8 +105,8 @@ class CertificateMetadata(TypedDict):
     not_valid_after: str
     expired: bool
     valid: bool
-    domains: Optional[list[str]]
-    logotype_sha256: Optional[str]
+    domains: list[str] | None
+    logotype_sha256: str | None
     warnings: list[str]
     validation_errors: list[str]
 
@@ -131,21 +131,21 @@ class BIMIParseResult(TypedDict):
     """Result from parsing a BIMI record"""
 
     tags: dict[str, BIMITagValue]
-    image: Union[SVGMetadata, dict[str, str]]
-    certificate: Union[CertificateMetadata, dict[str, str]]
+    image: SVGMetadata | dict[str, str]
+    certificate: CertificateMetadata | dict[str, str]
     warnings: list[str]
 
 
 class BIMICheckResult(TypedDict, total=False):
     """Result from checking BIMI for a domain"""
 
-    record: Optional[str]
+    record: str | None
     valid: bool
     selector: str
     location: str
     tags: dict[str, BIMITagValue]
-    image: Union[SVGMetadata, dict[str, str]]
-    certificate: Union[CertificateMetadata, dict[str, str]]
+    image: SVGMetadata | dict[str, str]
+    certificate: CertificateMetadata | dict[str, str]
     warnings: list[str]
     error: str
 
@@ -424,7 +424,7 @@ _verifier = _builder.build_client_verifier()
 class BIMIError(Exception):
     """Raised when a fatal BIMI error occurs"""
 
-    def __init__(self, msg: str, data: Optional[dict] = None):
+    def __init__(self, msg: str, data: dict | None = None):
         """
         Args:
             msg (str): The error message
@@ -490,7 +490,7 @@ class _BIMIGrammar(pyleri.Grammar):
     )
 
 
-def get_svg_metadata(raw_xml: Union[str, bytes]) -> dict[str, Any]:
+def get_svg_metadata(raw_xml: str | bytes) -> dict[str, Any]:
     metadata = {}
     if isinstance(raw_xml, bytes):
         raw_xml = raw_xml.decode(errors="ignore")
@@ -556,8 +556,8 @@ def check_svg_requirements(svg_metadata: dict) -> list[str]:
 
 
 def extract_logo_from_certificate(
-    cert: Union[x509.Certificate, bytes],
-) -> Optional[bytes]:
+    cert: x509.Certificate | bytes,
+) -> bytes | None:
     try:
         if not isinstance(cert, x509.Certificate):
             cert = load_pem_x509_certificates(cert)[1]
@@ -809,9 +809,9 @@ def get_certificate_metadata(pem_crt: bytes, *, domain=None) -> dict[str, Any]:
 def _query_bimi_record(
     domain: str,
     *,
-    selector: Optional[str] = "default",
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    selector: str | None = "default",
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ):
@@ -906,9 +906,9 @@ def _query_bimi_record(
 def query_bimi_record(
     domain: str,
     *,
-    selector: Optional[str] = "default",
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    selector: str | None = "default",
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> BIMIQueryResult:
@@ -992,8 +992,8 @@ def query_bimi_record(
 def parse_bimi_record(
     record: str,
     *,
-    domain: Optional[str] = None,
-    parsed_dmarc_record: Optional[Union[DMARCResults, DMARCErrorResults]] = None,
+    domain: str | None = None,
+    parsed_dmarc_record: DMARCResults | DMARCErrorResults | None = None,
     include_tag_descriptions: bool = False,
     syntax_error_marker: str = SYNTAX_ERROR_MARKER,
     http_timeout: float = DEFAULT_HTTP_TIMEOUT,
@@ -1208,10 +1208,10 @@ def check_bimi(
     domain: str,
     *,
     selector: str = "default",
-    parsed_dmarc_record: Optional[Union[DMARCResults, DMARCErrorResults]] = None,
+    parsed_dmarc_record: DMARCResults | DMARCErrorResults | None = None,
     include_tag_descriptions: bool = False,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> BIMICheckResult:

--- a/checkdmarc/dmarc.py
+++ b/checkdmarc/dmarc.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Sequence
-from typing import Literal, Optional, TypedDict, Union, overload
+from typing import Literal, TypedDict, overload
 
 import dns.exception
 import dns.resolver
@@ -61,7 +61,7 @@ class _DMARCBestPracticeWarning(_DMARCWarning):
 class DMARCError(Exception):
     """Raised when a fatal DMARC error occurs"""
 
-    def __init__(self, msg: str, data: Optional[DMARCErrorData] = None):
+    def __init__(self, msg: str, data: DMARCErrorData | None = None):
         """
         Args:
             msg (str): The error message
@@ -150,16 +150,16 @@ class DMARCTagMapItem(TypedDict):
 
 
 class DMARCTagMapItemWithDefault(DMARCTagMapItem):
-    default: Union[str, int]
+    default: str | int
 
 
 class DMARCTagMapItemWithValues(DMARCTagMapItem):
-    values: dict[str, Union[str, int]]
+    values: dict[str, str | int]
 
 
 class DMARCTagMapItemWithDefaultAndValues(DMARCTagMapItem):
-    default: Union[str, int]
-    values: dict[str, Union[str, int]]
+    default: str | int
+    values: dict[str, str | int]
 
 
 class DMARCTagMap(TypedDict):
@@ -178,7 +178,7 @@ class DMARCTagMap(TypedDict):
 
 class DMARCTagDetails(TypedDict):
     name: str
-    default: Union[str, int, None]
+    default: str | int | None
     description: str
 
 
@@ -193,21 +193,21 @@ class ParsedDMARCReportURI(TypedDict):
 
     scheme: str
     address: str
-    size_limit: Union[str, None]
+    size_limit: str | None
 
 
 # TypedDicts for DMARC tag values
 class DMARCTagValue(TypedDict):
     """Base structure for a DMARC tag value without descriptions"""
 
-    value: Union[str, int, list[ParsedDMARCReportURI]]
+    value: str | int | list[ParsedDMARCReportURI]
     explicit: bool
 
 
 class _DMARCTagValueOptionalFields(TypedDict, total=False):
     """Optional fields for DMARC tag values with descriptions"""
 
-    default: Union[str, int]
+    default: str | int
 
 
 class DMARCTagValueWithDescription(DMARCTagValue, _DMARCTagValueOptionalFields):
@@ -259,7 +259,7 @@ class DMARCResults(TypedDict):
     location: str
     valid: Literal[True]
     warnings: list[str]
-    tags: Union[DMARCParsedTags, DMARCParsedTagsWithDescriptions]
+    tags: DMARCParsedTags | DMARCParsedTagsWithDescriptions
 
 
 class _DMARCErrorResultsOptionalFields(TypedDict, total=False):
@@ -271,8 +271,8 @@ class _DMARCErrorResultsOptionalFields(TypedDict, total=False):
 class DMARCErrorResults(_DMARCErrorResultsOptionalFields):
     """Error return type for check_dmarc"""
 
-    record: Optional[str]
-    location: Optional[str]
+    record: str | None
+    location: str | None
     valid: Literal[False]
     error: str
 
@@ -653,13 +653,13 @@ dmarc_tags: DMARCTagMap = {
 def _query_dmarc_record(
     domain: str,
     *,
-    nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
     ignore_unrelated_records: bool = False,
     apex_fallback: bool = True,
-) -> Union[str, None]:
+) -> str | None:
     """
     Queries DNS for a DMARC record
 
@@ -772,8 +772,8 @@ def _query_dmarc_record(
 def query_dmarc_record(
     domain: str,
     *,
-    nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
     ignore_unrelated_records: bool = False,
@@ -891,7 +891,7 @@ def query_dmarc_record(
 
 
 def get_dmarc_tag_description(
-    tag: str, value: Optional[Union[str, list[str]]] = None
+    tag: str, value: str | list[str] | None = None
 ) -> DMARCTagDetails:
     """
     Get the name, default value, and description for a DMARC tag, amd/or a
@@ -978,9 +978,9 @@ def parse_dmarc_report_uri(uri: str) -> ParsedDMARCReportURI:
 def check_wildcard_dmarc_report_authorization(
     domain: str,
     *,
-    nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
     ignore_unrelated_records: bool = False,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> bool:
@@ -1046,9 +1046,9 @@ def verify_dmarc_report_destination(
     source_domain: str,
     destination_domain: str,
     *,
-    nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
     ignore_unrelated_records: bool = False,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> None:
@@ -1138,9 +1138,9 @@ def parse_dmarc_record(
     *,
     parked: bool = False,
     include_tag_descriptions: Literal[False] = False,
-    nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
     ignore_unrelated_records: bool = False,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
     syntax_error_marker: str = SYNTAX_ERROR_MARKER,
@@ -1154,9 +1154,9 @@ def parse_dmarc_record(
     *,
     parked: bool = False,
     include_tag_descriptions: Literal[True],
-    nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
     ignore_unrelated_records: bool = False,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
     syntax_error_marker: str = SYNTAX_ERROR_MARKER,
@@ -1169,13 +1169,13 @@ def parse_dmarc_record(
     *,
     parked: bool = False,
     include_tag_descriptions: bool = False,
-    nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
     ignore_unrelated_records: bool = False,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
     syntax_error_marker: str = SYNTAX_ERROR_MARKER,
-) -> Union[ParsedDMARCRecord, ParsedDMARCRecordWithDescriptions]:
+) -> ParsedDMARCRecord | ParsedDMARCRecordWithDescriptions:
     """
     Parses a DMARC record
 
@@ -1502,8 +1502,8 @@ def get_dmarc_record(
     domain: str,
     *,
     include_tag_descriptions: Literal[False] = False,
-    nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> DMARCRecord: ...
@@ -1514,8 +1514,8 @@ def get_dmarc_record(
     domain: str,
     *,
     include_tag_descriptions: Literal[True],
-    nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> DMARCRecordWithDescriptions: ...
@@ -1525,11 +1525,11 @@ def get_dmarc_record(
     domain: str,
     *,
     include_tag_descriptions: bool = False,
-    nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
-) -> Union[DMARCRecord, DMARCRecordWithDescriptions]:
+) -> DMARCRecord | DMARCRecordWithDescriptions:
     """
     Retrieves a DMARC record for a domain and parses it
 
@@ -1606,11 +1606,11 @@ def check_dmarc(
     parked: bool = False,
     include_dmarc_tag_descriptions: bool = False,
     ignore_unrelated_records: bool = False,
-    nameservers: Optional[Sequence[Union[str, Nameserver]]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
-) -> Union[DMARCResults, DMARCErrorResults]:
+) -> DMARCResults | DMARCErrorResults:
     """
     Returns a dictionary with a parsed DMARC record or an error
 

--- a/checkdmarc/dnssec.py
+++ b/checkdmarc/dnssec.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
 from collections.abc import Sequence
 
 import dns.dnssec
@@ -53,10 +52,10 @@ TLSA_CACHE = ExpiringDict(
 def get_dnskey(
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
-    cache: Optional[ExpiringDict] = None,
-) -> Optional[dict]:
+    cache: ExpiringDict | None = None,
+) -> dict | None:
     """
     Get a DNSKEY RRSet on the given domain
 
@@ -114,9 +113,9 @@ def get_dnskey(
 def test_dnssec(
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
-    cache: Optional[ExpiringDict] = None,
+    cache: ExpiringDict | None = None,
 ) -> bool:
     """
     Check for DNSSEC on the given domain
@@ -180,11 +179,11 @@ def test_dnssec(
 def get_tlsa_records(
     hostname: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     port: int = 25,
     protocol: str = "tcp",
-    cache: Optional[ExpiringDict] = None,
+    cache: ExpiringDict | None = None,
 ) -> list[str]:
     """
     Checks for TLSA records on the given hostname

--- a/checkdmarc/mta_sts.py
+++ b/checkdmarc/mta_sts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Optional, Union, TypedDict, Literal
+from typing import TypedDict, Literal
 from collections.abc import Sequence
 
 import dns.resolver
@@ -49,7 +49,7 @@ MTA_STS_MX_REGEX = re.compile(MTA_STS_MX_REGEX_STRING, re.IGNORECASE)
 class MTASTSError(Exception):
     """Raised when a fatal MTA-STS error occurs"""
 
-    def __init__(self, msg: str, data: Optional[dict] = None):
+    def __init__(self, msg: str, data: dict | None = None):
         """
         Args:
             msg (str): The error message
@@ -123,7 +123,7 @@ MTASTSTagsWithDescription = dict[
 
 
 class ParsedMTASTSRecord(TypedDict):
-    tags: Union[MTASTSTags, MTASTSTagsWithDescription]
+    tags: MTASTSTags | MTASTSTagsWithDescription
     warnings: list[str]
 
 
@@ -134,11 +134,11 @@ class MTASTSFailure(TypedDict):
 
 class MTASTSSuccess(TypedDict):
     valid: bool
-    tags: Union[MTASTSTags, MTASTSTagsWithDescription]
+    tags: MTASTSTags | MTASTSTagsWithDescription
     warnings: list[str]
 
 
-MTASTSResults = Union[MTASTSSuccess, MTASTSFailure]
+MTASTSResults = MTASTSSuccess | MTASTSFailure
 
 
 class DownloadedMTASTSPolicy(TypedDict):
@@ -148,7 +148,7 @@ class DownloadedMTASTSPolicy(TypedDict):
 
 class ParsedMTASTSPolicy(TypedDict):
     version: Literal["STSv1"]
-    mode: Union[Literal["enforce"], Literal["testing"], Literal["none"]]
+    mode: Literal["enforce"] | Literal["testing"] | Literal["none"]
     max_age: int
     mx: list[str]
 
@@ -170,7 +170,7 @@ class MTASTSCheckFailure(TypedDict):
     error: str
 
 
-MTASTSCheckResults = Union[MTASTSCheckSuccess, MTASTSCheckFailure]
+MTASTSCheckResults = MTASTSCheckSuccess | MTASTSCheckFailure
 
 
 class _STSGrammar(pyleri.Grammar):
@@ -211,8 +211,8 @@ STS_TAG_VALUE_REGEX = re.compile(MTA_STS_TAG_VALUE_REGEX_STRING, re.IGNORECASE)
 def query_mta_sts_record(
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> MTASTSQueryResults:
@@ -537,8 +537,8 @@ def parse_mta_sts_policy(policy: str) -> MTASTSPolicyParsingResults:
 def check_mta_sts(
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> MTASTSCheckResults:

--- a/checkdmarc/smtp.py
+++ b/checkdmarc/smtp.py
@@ -8,7 +8,7 @@ import platform
 import smtplib
 import socket
 import ssl
-from typing import TypedDict, Optional, Union
+from typing import TypedDict
 from collections.abc import Sequence
 
 import dns.exception
@@ -68,7 +68,7 @@ class MXResultsFailure(TypedDict):
     error: str
 
 
-MXResults = Union[MXResultsSuccess, MXResultsFailure]
+MXResults = MXResultsSuccess | MXResultsFailure
 
 
 class SMTPError(Exception):
@@ -78,8 +78,8 @@ class SMTPError(Exception):
 def test_tls(
     hostname: str,
     *,
-    ssl_context: Optional[ssl.SSLContext] = None,
-    cache: Optional[ExpiringDict] = None,
+    ssl_context: ssl.SSLContext | None = None,
+    cache: ExpiringDict | None = None,
     timeout: float = DEFAULT_SMTP_TIMEOUT,
 ) -> bool:
     """
@@ -185,8 +185,8 @@ def test_tls(
 def test_starttls(
     hostname: str,
     *,
-    ssl_context: Optional[ssl.SSLContext] = None,
-    cache: Optional[ExpiringDict] = None,
+    ssl_context: ssl.SSLContext | None = None,
+    cache: ExpiringDict | None = None,
     timeout: float = DEFAULT_SMTP_TIMEOUT,
 ) -> bool:
     """
@@ -296,11 +296,11 @@ def get_mx_hosts(
     domain: str,
     *,
     skip_tls: bool = False,
-    approved_hostnames: Optional[list[str]] = None,
-    mta_sts_mx_patterns: Optional[list[str]] = None,
+    approved_hostnames: list[str] | None = None,
+    mta_sts_mx_patterns: list[str] | None = None,
     parked: bool = False,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> MXResultsSuccess:
@@ -485,11 +485,11 @@ def get_mx_hosts(
 def check_mx(
     domain: str,
     *,
-    approved_mx_hostnames: Optional[list[str]] = None,
-    mta_sts_mx_patterns: Optional[list[str]] = None,
+    approved_mx_hostnames: list[str] | None = None,
+    mta_sts_mx_patterns: list[str] | None = None,
     skip_tls: bool = False,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> MXResults:

--- a/checkdmarc/smtp_tls_reporting.py
+++ b/checkdmarc/smtp_tls_reporting.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Optional, TypedDict, Union, Literal
+from typing import TypedDict, Literal
 from collections.abc import Sequence
 
 import dns.exception
@@ -61,7 +61,7 @@ SMTPTLSREPORTING_URI_REGEX = re.compile(
 class SMTPTLSReportingError(Exception):
     """Raised when a fatal SMTP TLS Reporting error occurs"""
 
-    def __init__(self, msg: str, data: Optional[dict] = None):
+    def __init__(self, msg: str, data: dict | None = None):
         """
         Args:
             msg (str): The error message
@@ -131,7 +131,7 @@ class SMTPTLSReportingQueryResults(TypedDict):
 
 
 class SMTPTLSReportingTagValue(TypedDict):
-    value: Union[str, list[str]]
+    value: str | list[str]
 
 
 class _SMTPTLSReportingTagValueOptional(TypedDict, total=False):
@@ -150,7 +150,7 @@ SMTPTLSReportingTagsWithDescription = dict[str, SMTPTLSReportingTagValueWithDesc
 
 
 class ParsedSMTPTLSReportingRecord(TypedDict):
-    tags: Union[SMTPTLSReportingTags, SMTPTLSReportingTagsWithDescription]
+    tags: SMTPTLSReportingTags | SMTPTLSReportingTagsWithDescription
     warnings: list[str]
 
 
@@ -161,11 +161,11 @@ class SMTPTLSReportingFailure(TypedDict):
 
 class SMTPTLSReportingSuccess(TypedDict):
     valid: Literal[True]
-    tags: Union[SMTPTLSReportingTags, SMTPTLSReportingTagsWithDescription]
+    tags: SMTPTLSReportingTags | SMTPTLSReportingTagsWithDescription
     warnings: list[str]
 
 
-SMTPTLSReportingResults = Union[SMTPTLSReportingSuccess, SMTPTLSReportingFailure]
+SMTPTLSReportingResults = SMTPTLSReportingSuccess | SMTPTLSReportingFailure
 
 smtp_rpt_tags = {
     "v": {"name": "Version", "description": "Must be TLSRPTv1", "required": True},
@@ -184,8 +184,8 @@ smtp_rpt_tags = {
 def query_smtp_tls_reporting_record(
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> SMTPTLSReportingQueryResults:
@@ -391,8 +391,8 @@ def parse_smtp_tls_reporting_record(
 def check_smtp_tls_reporting(
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> SMTPTLSReportingResults:

--- a/checkdmarc/soa.py
+++ b/checkdmarc/soa.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Optional, TypedDict, Union
+from typing import TypedDict
 from collections.abc import Sequence
 
 import dns.resolver
@@ -31,11 +31,11 @@ class SOARecordSuccessful(TypedDict):
 
 
 class SOARecordError(TypedDict):
-    record: Union[str, None]
+    record: str | None
     error: str
 
 
-SOARecordResults = Union[SOARecordSuccessful, SOARecordError]
+SOARecordResults = SOARecordSuccessful | SOARecordError
 
 
 def soa_rname_to_email(rname: str) -> str:
@@ -93,8 +93,8 @@ def parse_soa_string(rr: str) -> ParsedSOARecord:
 def check_soa(
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> SOARecordResults:

--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import ipaddress
 import logging
 import re
-from typing import Optional, TypedDict, Union
+from typing import TypedDict
 from collections.abc import Sequence
 
 import dns
@@ -77,7 +77,7 @@ MACRO_DELIMS = set(".-+,/_=")
 class SPFError(Exception):
     """Raised when a fatal SPF error occurs"""
 
-    def __init__(self, msg: str, data: Optional[dict] = None):
+    def __init__(self, msg: str, data: dict | None = None):
         """
         Args:
             msg (str): The error message
@@ -102,7 +102,7 @@ class _SPFDuplicateInclude(_SPFWarning):
 class SPFRecordNotFound(SPFError):
     """Raised when an SPF record could not be found"""
 
-    def __init__(self, error: Union[Exception, str], domain: str):
+    def __init__(self, error: Exception | str, domain: str):
         if isinstance(error, dns.exception.Timeout):
             error.kwargs["timeout"] = round(error.kwargs["timeout"], 1)
         self.error = error
@@ -185,37 +185,35 @@ class ParsedSPFMXMechanism(SPFDNSLookupMechanism):
 
 
 class SPFIncludeMechanism(SPFDNSLookupMechanism):
-    record: Union[str, None]
-    parsed: Union[ParsedSPFRecord, None]
+    record: str | None
+    parsed: ParsedSPFRecord | None
     warnings: list[str]
 
 
 class SPFRedirect(TypedDict):
     domain: str
-    record: Union[str, None]
+    record: str | None
     dns_lookups: int
     void_dns_lookups: int
-    parsed: Union[ParsedSPFRecord, None]
+    parsed: ParsedSPFRecord | None
     warnings: list[str]
 
 
 class ParsedSPFRecord(TypedDict):
     mechanisms: list[
-        Union[
-            SPFMechanism,
-            SPFDNSLookupMechanism,
-            SPFIncludeMechanism,
-            SPFAMechanism,
-            ParsedSPFMXMechanism,
-        ]
+        SPFMechanism
+        | SPFDNSLookupMechanism
+        | SPFIncludeMechanism
+        | SPFAMechanism
+        | ParsedSPFMXMechanism
     ]
-    redirect: Union[SPFRedirect, None]
-    exp: Union[str, None]
+    redirect: SPFRedirect | None
+    exp: str | None
     all: str
 
 
 class ParsedSPFRecordSuccess(TypedDict):
-    record: Union[None, str]
+    record: None | str
     dns_lookups: int
     void_dns_lookups: int
     parsed: ParsedSPFRecord
@@ -223,10 +221,10 @@ class ParsedSPFRecordSuccess(TypedDict):
 
 
 class ParsedSPFRecordError(ParsedSPFRecordSuccess):
-    error: Union[str, DNSException]
+    error: str | DNSException
 
 
-SPFRecordResults = Union[ParsedSPFRecordSuccess, ParsedSPFRecordError]
+SPFRecordResults = ParsedSPFRecordSuccess | ParsedSPFRecordError
 
 spf_qualifiers: dict[str, str] = {
     "": "pass",
@@ -241,8 +239,8 @@ def ptr_match(
     ip_address: str,
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> bool:
@@ -385,9 +383,9 @@ def _validate_spf_macros(
 def query_spf_record(
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
     quoted_txt_segments: bool = False,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> SPFQueryResults:
@@ -561,10 +559,10 @@ def parse_spf_record(
     *,
     ignore_too_many_lookups: bool = False,
     parked: bool = False,
-    seen: Optional[list] = None,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
-    recursion: Optional[list[str]] = None,
+    seen: list | None = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
+    recursion: list[str] | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
     syntax_error_marker: str = SYNTAX_ERROR_MARKER,
@@ -1255,8 +1253,8 @@ def parse_spf_record(
 def get_spf_record(
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> SPFRecordResults:
@@ -1312,8 +1310,8 @@ def check_spf(
     domain: str,
     *,
     parked: bool = False,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> dict:

--- a/checkdmarc/utils.py
+++ b/checkdmarc/utils.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 import re
 import unicodedata
-from typing import Optional, TypedDict, Union
+from typing import TypedDict
 from collections.abc import Sequence
 
 import dns.exception
@@ -71,10 +71,7 @@ class NameserverResultError(TypedDict):
     error: str
 
 
-NameserverResult = Union[
-    NameserverResultOk,
-    NameserverResultError,
-]
+NameserverResult = NameserverResultOk | NameserverResultError
 
 
 class MXHost(TypedDict):
@@ -137,12 +134,12 @@ def query_dns(
     record_type: str,
     *,
     quoted_txt_segments: bool = False,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
     _attempt: int = 0,
-    cache: Optional[ExpiringDict] = None,
+    cache: ExpiringDict | None = None,
 ) -> list[str]:
     """
     Queries DNS
@@ -276,8 +273,8 @@ def query_dns(
 def get_a_records(
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> list[str]:
@@ -325,8 +322,8 @@ def get_a_records(
 def get_reverse_dns(
     ip_address: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> list[str]:
@@ -370,9 +367,9 @@ def get_reverse_dns(
 def get_txt_records(
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
     quoted_txt_segments: bool = False,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> list[str]:
@@ -418,8 +415,8 @@ def get_txt_records(
 def get_soa_record(
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> str:
@@ -464,9 +461,9 @@ def get_soa_record(
 def get_nameservers(
     domain: str,
     *,
-    approved_nameservers: Optional[Sequence[str | Nameserver]] = None,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    approved_nameservers: Sequence[str | Nameserver] | None = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> NameserverResultOk:
@@ -526,8 +523,8 @@ def get_nameservers(
 def get_mx_records(
     domain: str,
     *,
-    nameservers: Optional[Sequence[str | Nameserver]] = None,
-    resolver: Optional[dns.resolver.Resolver] = None,
+    nameservers: Sequence[str | Nameserver] | None = None,
+    resolver: dns.resolver.Resolver | None = None,
     timeout: float = DEFAULT_DNS_TIMEOUT,
     retries: int = DEFAULT_DNS_MAX_RETRIES,
 ) -> list[MXHost]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "checkdmarc"
 dynamic = [
     "version",
 ]
-python_requires = ">=3.10"
+requires-python = ">=3.10"
 description = "A Python module and command line parser for SPF and DMARC records"
 readme = "README.md"
 license = "Apache-2.0"
@@ -25,6 +25,11 @@ keywords = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: Apache Software License",
     "Topic :: Security",


### PR DESCRIPTION
Addresses the two stylistic items flagged during the AGENTS.md audit, plus a metadata bug found along the way.

## 1. Modern type annotations (PEP 604)

Converted `Optional[X]` → `X | None` and `Union[X, Y]` → `X | Y` across all modules (171 sites), and removed the now-unused `Optional`/`Union` imports. This aligns with the AGENTS.md "modern type annotations" guidance and was the larger of the two items noted in the audit. The bulk was done with `ruff`'s pyupgrade rules (UP007/UP045); the 7 runtime type-alias assignments (e.g. `SPFRecordResults = ... | ...`) were converted by hand.

## 2. `requires-python` (the second item — and a real metadata bug)

The "pyright is a version behind" item turned out to be a non-issue: the repo doesn't pin pyright, and CI already runs `pip install --upgrade pyright`, so it always uses the latest. **No change needed there.**

But verifying the Python floor surfaced a genuine bug. The `[project]` table declared the floor with `python_requires = ">=3.10"` — that's the old `setup.py`/`setup.cfg` key. PEP 621 (and hatchling) only recognize **`requires-python`**, so `python_requires` was silently ignored and the published wheel/sdist advertised **no** minimum Python. pip would therefore install checkdmarc on end-of-life 3.8/3.9, where the new `X | Y` runtime aliases fail to import.

Fixed by renaming the key to `requires-python` and adding per-version classifiers for 3.10–3.14. Built metadata now reports `Requires-Python: >=3.10` (previously absent).

## Why `>=3.10` is the correct floor

Per the [Python devguide](https://devguide.python.org/versions/), as of mid-2026: 3.9 reached end-of-life on 2025-10-31, making **3.10 the oldest non-EOL version** (security phase, EOL 2026-10). It's also the interpreter shipped in Ubuntu 22.04 LTS (supported to 2027). PEP 604 unions are a core 3.10.0 language feature, so the conversion is valid across the entire supported range — the floor is not lowered.

## Verification

- **Full suite on real Python 3.10.19**: 444 passed, 11 skipped (import smoke test exercises the runtime aliases at module load)
- Full suite on 3.12: 444 passed, 11 skipped
- `ruff` clean, `pyright` (latest, 1.1.410) 0 errors
- `grep -rn "Optional\[\|Union\[" checkdmarc/` returns nothing

No runtime/API behavior change; annotations only, plus the metadata fix. Rides in the unreleased 5.17.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)