### PR TITLE
Fix DNSSEC crash on answers holding a chain of names (#265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Honor a caller-supplied `cache` in `get_dnskey()` when it falls back to the base domain; the fallback previously wrote to the module-level cache instead, leaving the caller's cache empty and leaking results between callers
 - Read TLSA results from the caller-supplied `cache` in `get_tlsa_records()`, which previously wrote to that cache but always read from the module-level one, so a caller's own cached entries were never used
 
+## 5.17.3
+
 ### Changed
 
 - Narrow the advisory SPF record size check to catch only `UnicodeError` (raised when a record can't be encoded to UTF-8) instead of swallowing every exception, and log the skip at debug level

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 5.17.3
+## 5.17.4
+
+### Fixed
+
+- Stop crashing with `AttributeError: 'NoneType' object has no attribute 'name'` when checking a domain whose DNS answer contains a chain of names, such as `aws.amazon.com`. The DNSSEC check assumed a two-record answer was always a record plus its signature, so it passed a missing signature to the validator; it now selects the record and signature by name and type ([issue #265](https://github.com/domainaware/checkdmarc/issues/265))
+- Stop treating the first record in a DNSKEY answer as a key regardless of its type, which made a domain that answers with a chain of names appear to have a key it does not have. The base domain is now checked instead, as it already was for an empty answer
+- Apply the same record selection to the TLSA lookup, which could crash the same way for a mail host whose name points at another name
+- Honor a caller-supplied `cache` in `get_dnskey()` when it falls back to the base domain; the fallback previously wrote to the module-level cache instead, leaving the caller's cache empty and leaking results between callers
+- Read TLSA results from the caller-supplied `cache` in `get_tlsa_records()`, which previously wrote to that cache but always read from the module-level one, so a caller's own cached entries were never used
 
 ### Changed
 

--- a/checkdmarc/_constants.py
+++ b/checkdmarc/_constants.py
@@ -19,7 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-__version__ = "5.17.3"
+__version__ = "5.17.4"
 
 OS = platform.system()
 OS_RELEASE = platform.release()

--- a/checkdmarc/dnssec.py
+++ b/checkdmarc/dnssec.py
@@ -13,6 +13,7 @@ import dns.query
 import dns.resolver
 import dns.rdatatype
 import dns.name
+import dns.rrset
 from dns.nameserver import Nameserver
 from dns.rdatatype import RdataType
 from expiringdict import ExpiringDict
@@ -47,6 +48,44 @@ DNSKEY_CACHE = ExpiringDict(
 TLSA_CACHE = ExpiringDict(
     max_len=DNSSEC_CACHE_MAX_LEN, max_age_seconds=DNSSEC_CACHE_MAX_AGE_SECONDS
 )
+
+
+def _find_record_and_signature(
+    answer: Sequence[dns.rrset.RRset],
+    name: dns.name.Name,
+    rdatatype: RdataType,
+) -> tuple[dns.rrset.RRset | None, dns.rrset.RRset | None]:
+    """
+    Pick the record set of the requested type out of a DNS answer, along with
+    the signature that covers it
+
+    An answer can hold more than one record set. A name that points at another
+    name, for example, returns every link in that chain, and each link may sit
+    in a different zone with a different signature (or no signature at all).
+    Picking records out by name and type keeps a record from being paired with
+    a signature that belongs to something else, or with no signature at all.
+
+    Args:
+        answer (Sequence): The answer section of a DNS response
+        name (dns.name.Name): The name that was queried
+        rdatatype (RdataType): The record type that was queried
+
+    Returns:
+        tuple: The matching record set and its signature, either of which is
+        ``None`` when the answer does not contain it
+    """
+    rrset = None
+    rrsig = None
+    for rset in answer:
+        if rset.name != name:
+            continue
+        if rset.rdtype == RdataType.RRSIG:
+            if rset.covers == rdatatype:
+                rrsig = rset
+        elif rset.rdtype == rdatatype:
+            rrset = rset
+
+    return rrset, rrsig
 
 
 def get_dnskey(
@@ -86,22 +125,26 @@ def get_dnskey(
         try:
             response = dns.query.tcp(request, str(nameserver), timeout=timeout)
             if response is not None:
-                answer = response.answer
-                if len(answer) == 0:
+                name = dns.name.from_text(domain)
+                rrset, _ = _find_record_and_signature(
+                    response.answer, name, RdataType.DNSKEY
+                )
+                # An answer that holds no DNSKEY for this name means the same
+                # thing as an empty answer: the name is not the apex of a
+                # signed zone. A name that points at another name answers with
+                # that chain rather than with a key, so check the base domain.
+                if rrset is None:
                     logging.debug(f"No DNSKEY records found at {domain}")
                     base_domain = get_base_domain(domain)
                     if domain != base_domain:
                         return get_dnskey(
-                            base_domain, nameservers=nameservers, timeout=timeout
+                            base_domain,
+                            nameservers=nameservers,
+                            timeout=timeout,
+                            cache=cache,
                         )
                     cache[domain] = None
                     return None
-                rrset = None
-                for rset in answer:
-                    if rset.rdtype != RdataType.RRSIG:
-                        rrset = rset
-                        break
-                name = dns.name.from_text(f"{domain}.")
                 key = {name: rrset}
                 cache[domain] = key
                 return key
@@ -149,22 +192,18 @@ def test_dnssec(
         dns.rdatatype.NS,
         dns.rdatatype.CNAME,
     ]
+    name = dns.name.from_text(domain)
     for rdatatype in rdatatypes:
         request = dns.message.make_query(domain, rdatatype, want_dnssec=True)
         for nameserver in nameservers:
             try:
                 response = dns.query.tcp(request, str(nameserver), timeout=timeout)
                 if response is not None:
-                    answer = response.answer
-                    if len(answer) != 2:
+                    rrset, rrsig = _find_record_and_signature(
+                        response.answer, name, rdatatype
+                    )
+                    if rrset is None or rrsig is None:
                         continue
-                    rrset = None
-                    rrsig = None
-                    for rset in answer:
-                        if rset.rdtype == RdataType.RRSIG:
-                            rrsig = rset
-                        else:
-                            rrset = rset
                     dns.dnssec.validate(rrset, rrsig, key)
                     logging.debug(f"Found a signed {rdatatype.name} record")
                     cache[domain] = True
@@ -206,11 +245,10 @@ def get_tlsa_records(
         cache = TLSA_CACHE
 
     query_hostname = f"_{port}._{protocol}.{hostname}"
-    if isinstance(cache, ExpiringDict):
-        if query_hostname in TLSA_CACHE:
-            cached_results = TLSA_CACHE[query_hostname]
-            if isinstance(cached_results, list):
-                return cached_results
+    if query_hostname in cache:
+        cached_results = cache[query_hostname]
+        if isinstance(cached_results, list):
+            return cached_results
     tlsa_records: list[str] = []
     logging.debug(f"Checking for TLSA records at {query_hostname}")
     request = dns.message.make_query(
@@ -222,8 +260,12 @@ def get_tlsa_records(
         try:
             response = dns.query.tcp(request, str(nameserver), timeout=timeout)
             if response is not None:
-                answer = response.answer
-                if len(answer) != 2:
+                rrset, rrsig = _find_record_and_signature(
+                    response.answer,
+                    dns.name.from_text(query_hostname),
+                    RdataType.TLSA,
+                )
+                if rrset is None or rrsig is None:
                     return tlsa_records
                 dnskey = get_dnskey(
                     domain=hostname, nameservers=nameservers, timeout=timeout
@@ -234,17 +276,9 @@ def get_tlsa_records(
                         f"a DNSKEY record to verify them"
                     )
                     return tlsa_records
-                rrset = None
-                rrsig = None
-                for rset in answer:
-                    if rset.rdtype == RdataType.RRSIG:
-                        rrsig = rset
-                    else:
-                        rrset = rset
-                if rrset is not None:
-                    dns.dnssec.validate(rrset, rrsig, dnskey)
-                    tlsa_records = list(map(lambda x: str(x), list(rrset.items.keys())))
-                    cache[query_hostname] = tlsa_records
+                dns.dnssec.validate(rrset, rrsig, dnskey)
+                tlsa_records = list(map(lambda x: str(x), list(rrset.items.keys())))
+                cache[query_hostname] = tlsa_records
                 return tlsa_records
         except (dns.exception.DNSException, OSError, EOFError) as e:
             logging.debug(f"TLSA query error: {e}")

--- a/tests/test_dnssec.py
+++ b/tests/test_dnssec.py
@@ -4,6 +4,12 @@ import os
 import unittest
 from unittest.mock import MagicMock, patch
 
+import dns.exception
+import dns.name
+import dns.rdatatype
+import dns.rrset
+from expiringdict import ExpiringDict
+
 import checkdmarc.dnssec
 
 OFFLINE_MODE = os.environ.get("GITHUB_ACTIONS", "false").lower() == "true"
@@ -15,6 +21,97 @@ mocked_only = unittest.skipUnless(
     OFFLINE_MODE, "Mocked counterpart skipped locally; network test covers this"
 )
 
+# A syntactically valid DNSKEY and RRSIG. Nothing here has to verify
+# cryptographically; these exist so the code under test sorts real record sets
+# by name and type instead of by their position in the answer.
+DNSKEY_RDATA = "257 3 13 mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ=="
+TLSA_RDATA = "3 1 1 " + "ab" * 32
+
+
+def _rrsig(
+    name: str, covered_type: str, signer: str = "example.com."
+) -> dns.rrset.RRset:
+    """Build an RRSIG record set covering the given record type"""
+    return dns.rrset.from_text(
+        name,
+        300,
+        "IN",
+        "RRSIG",
+        f"{covered_type} 13 2 300 20990101000000 20200101000000 1234 {signer} ab==",
+    )
+
+
+def _response(*rrsets: dns.rrset.RRset) -> MagicMock:
+    """A stand-in DNS response; only its answer section is read"""
+    response = MagicMock()
+    response.answer = list(rrsets)
+    return response
+
+
+def _cname_chain() -> tuple[dns.rrset.RRset, dns.rrset.RRset]:
+    """The answer shape from issue #265: a name pointing at another name
+
+    Two record sets, neither of them a signature. Code that assumes a
+    two-record answer is always "one record plus its signature" pairs the
+    second link of the chain with a missing signature.
+    """
+    return (
+        dns.rrset.from_text(
+            "aws.amazon.com.", 60, "IN", "CNAME", "tp.frontier.amazon.com."
+        ),
+        dns.rrset.from_text(
+            "tp.frontier.amazon.com.", 60, "IN", "CNAME", "d123.cloudfront.net."
+        ),
+    )
+
+
+def _fresh_cache() -> ExpiringDict:
+    return ExpiringDict(max_len=10, max_age_seconds=60)
+
+
+class TestFindRecordAndSignature(unittest.TestCase):
+    def testPairsRecordWithItsSignature(self):
+        """A record and the signature covering it are returned together"""
+        a = dns.rrset.from_text("example.com.", 300, "IN", "A", "192.0.2.1")
+        sig = _rrsig("example.com.", "A")
+        rrset, rrsig = checkdmarc.dnssec._find_record_and_signature(
+            [a, sig], dns.name.from_text("example.com"), dns.rdatatype.A
+        )
+        self.assertIs(rrset, a)
+        self.assertIs(rrsig, sig)
+
+    def testIgnoresRecordsForOtherNames(self):
+        """Records further along a chain belong to another name and are skipped"""
+        first, second = _cname_chain()
+        rrset, rrsig = checkdmarc.dnssec._find_record_and_signature(
+            [first, second], dns.name.from_text("aws.amazon.com"), dns.rdatatype.CNAME
+        )
+        self.assertIs(rrset, first)
+        self.assertIsNone(rrsig)
+
+    def testIgnoresSignatureCoveringAnotherType(self):
+        """An RRSIG over a different record type is not treated as a match"""
+        mx = dns.rrset.from_text(
+            "example.com.", 300, "IN", "MX", "10 mail.example.com."
+        )
+        rrset, rrsig = checkdmarc.dnssec._find_record_and_signature(
+            [mx, _rrsig("example.com.", "A")],
+            dns.name.from_text("example.com"),
+            dns.rdatatype.MX,
+        )
+        self.assertIs(rrset, mx)
+        self.assertIsNone(rrsig)
+
+    def testNameMatchIsCaseInsensitive(self):
+        """DNS names are case-insensitive, so casing must not defeat the match"""
+        a = dns.rrset.from_text("Example.COM.", 300, "IN", "A", "192.0.2.1")
+        rrset, _ = checkdmarc.dnssec._find_record_and_signature(
+            [a, _rrsig("example.com.", "A")],
+            dns.name.from_text("example.com"),
+            dns.rdatatype.A,
+        )
+        self.assertIs(rrset, a)
+
 
 class Test(unittest.TestCase):
     @network_test
@@ -22,32 +119,37 @@ class Test(unittest.TestCase):
         """Test known good DNSSEC"""
         self.assertEqual(checkdmarc.dnssec.test_dnssec("fbi.gov"), True)
 
+    @network_test
+    def testDNSSECNameChainDoesNotRaise(self):
+        """A name that points at an unsigned name reports no DNSSEC
+
+        Regression test for issue #265: aws.amazon.com answers with a chain of
+        names rather than with records of its own.
+        """
+        self.assertEqual(
+            checkdmarc.dnssec.test_dnssec("aws.amazon.com", nameservers=["1.1.1.1"]),
+            False,
+        )
+
     @mocked_only
     def testDNSSECMocked(self):
         """test_dnssec returns True when a record/RRSIG pair validates (mocked)
 
-        The full DNSSEC chain (DNSKEY -> RRSIG -> validated RRset) is
-        synthesised here; we are exercising the success branch of
-        test_dnssec, not the cryptographic validator itself.
+        The signature check itself is stubbed out; what is under test is that
+        test_dnssec finds the record and its signature and reports success.
         """
-        import dns.rdatatype
-
-        fake_response = MagicMock()
-        rrset = MagicMock()
-        rrset.rdtype = dns.rdatatype.A
-        rrsig = MagicMock()
-        rrsig.rdtype = dns.rdatatype.RRSIG
-        fake_response.answer = [rrset, rrsig]
-
-        from expiringdict import ExpiringDict
-
-        fresh_cache = ExpiringDict(max_len=10, max_age_seconds=60)
-        with patch("checkdmarc.dnssec.get_dnskey", return_value=MagicMock()):
-            with patch("dns.query.tcp", return_value=fake_response):
-                with patch("dns.dnssec.validate", return_value=None):
-                    result = checkdmarc.dnssec.test_dnssec(
-                        "example.com", cache=fresh_cache, nameservers=["192.0.2.1"]
-                    )
+        response = _response(
+            dns.rrset.from_text("example.com.", 300, "IN", "A", "192.0.2.1"),
+            _rrsig("example.com.", "A"),
+        )
+        with (
+            patch("checkdmarc.dnssec.get_dnskey", return_value=MagicMock()),
+            patch("dns.query.tcp", return_value=response),
+            patch("dns.dnssec.validate", return_value=None),
+        ):
+            result = checkdmarc.dnssec.test_dnssec(
+                "example.com", cache=_fresh_cache(), nameservers=["192.0.2.1"]
+            )
         self.assertTrue(result)
 
     def testDnssecFalseWhenNoKey(self):
@@ -59,9 +161,7 @@ class Test(unittest.TestCase):
 
     def testGetDnskeyCache(self):
         """get_dnskey uses cache"""
-        from expiringdict import ExpiringDict
-
-        cache = ExpiringDict(max_len=100, max_age_seconds=60)
+        cache = _fresh_cache()
         mock_key = {"test": "data"}
         cache["example.com"] = mock_key
         result = checkdmarc.dnssec.get_dnskey("example.com", cache=cache)
@@ -69,66 +169,79 @@ class Test(unittest.TestCase):
 
 
 class TestGetDnskey(unittest.TestCase):
-    @staticmethod
-    def _fresh_cache():
-        from expiringdict import ExpiringDict
-
-        return ExpiringDict(max_len=10, max_age_seconds=60)
-
     def testFound(self):
         """A DNSKEY answer at the apex is returned as a dict keyed by dns.name"""
-        import dns.rdatatype
-
-        rrset = MagicMock()
-        rrset.rdtype = dns.rdatatype.DNSKEY
-        response = MagicMock()
-        response.answer = [rrset]
+        rrset = dns.rrset.from_text("example.com.", 300, "IN", "DNSKEY", DNSKEY_RDATA)
+        response = _response(rrset, _rrsig("example.com.", "DNSKEY"))
 
         with patch("dns.query.tcp", return_value=response):
             result = checkdmarc.dnssec.get_dnskey(
-                "example.com",
-                nameservers=["1.1.1.1"],
-                cache=self._fresh_cache(),
+                "example.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
             )
         assert result is not None  # narrow Optional for pyright
-        # The single entry should map to the rrset we returned
-        self.assertIn(rrset, result.values())
+        self.assertEqual(result, {dns.name.from_text("example.com."): rrset})
 
     def testEmptyAnswerAtApexReturnsNone(self):
         """If the apex has no DNSKEY answer, get_dnskey returns None"""
-        response = MagicMock()
-        response.answer = []
-
-        with patch("dns.query.tcp", return_value=response):
+        with patch("dns.query.tcp", return_value=_response()):
             result = checkdmarc.dnssec.get_dnskey(
-                "example.com",
-                nameservers=["1.1.1.1"],
-                cache=self._fresh_cache(),
+                "example.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
             )
         self.assertIsNone(result)
 
+    def testNameChainAnswerIsNotMistakenForAKey(self):
+        """A chain of names in a DNSKEY answer must not be returned as a key
+
+        The apex here is the queried name, so there is nowhere left to fall
+        back to and the answer holds no key.
+        """
+        with patch("dns.query.tcp", return_value=_response(*_cname_chain())):
+            result = checkdmarc.dnssec.get_dnskey(
+                "amazon.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
+            )
+        self.assertIsNone(result)
+
+    def testNameChainAtSubdomainRecursesToBase(self):
+        """A subdomain answering with a chain of names falls back to the base domain"""
+        key = dns.rrset.from_text("amazon.com.", 300, "IN", "DNSKEY", DNSKEY_RDATA)
+        with patch(
+            "dns.query.tcp",
+            side_effect=[_response(*_cname_chain()), _response(key)],
+        ):
+            result = checkdmarc.dnssec.get_dnskey(
+                "aws.amazon.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
+            )
+        self.assertEqual(result, {dns.name.from_text("amazon.com."): key})
+
     def testEmptyAnswerAtSubdomainRecursesToBase(self):
         """A subdomain with no DNSKEY records recurses up to the base domain"""
-        import dns.rdatatype
-
-        empty_response = MagicMock()
-        empty_response.answer = []
-        rrset = MagicMock()
-        rrset.rdtype = dns.rdatatype.DNSKEY
-        valid_response = MagicMock()
-        valid_response.answer = [rrset]
-
-        with patch("dns.query.tcp", side_effect=[empty_response, valid_response]):
+        key = dns.rrset.from_text("example.com.", 300, "IN", "DNSKEY", DNSKEY_RDATA)
+        with patch("dns.query.tcp", side_effect=[_response(), _response(key)]):
             result = checkdmarc.dnssec.get_dnskey(
-                "sub.example.com",
-                nameservers=["1.1.1.1"],
-                cache=self._fresh_cache(),
+                "sub.example.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
             )
-        self.assertIsNotNone(result)
+        self.assertEqual(result, {dns.name.from_text("example.com."): key})
+
+    def testRecursionUsesTheCallersCache(self):
+        """The base domain result is stored in the cache the caller passed in
+
+        Without this the recursive lookup falls back to the module-level cache,
+        so the caller's cache stays empty and results leak between callers.
+        """
+        cache = _fresh_cache()
+        key = dns.rrset.from_text("example.com.", 300, "IN", "DNSKEY", DNSKEY_RDATA)
+        with patch("dns.query.tcp", side_effect=[_response(), _response(key)]):
+            checkdmarc.dnssec.get_dnskey(
+                "sub.example.com", nameservers=["1.1.1.1"], cache=cache
+            )
+        self.assertEqual(
+            cache["example.com"], {dns.name.from_text("example.com."): key}
+        )
+        self.assertNotIn("example.com", checkdmarc.dnssec.DNSKEY_CACHE)
 
     def testQueryExceptionCachedAsNone(self):
         """Network exceptions cache None and let the function return None"""
-        cache = self._fresh_cache()
+        cache = _fresh_cache()
         with patch("dns.query.tcp", side_effect=OSError("boom")):
             result = checkdmarc.dnssec.get_dnskey(
                 "example.com", nameservers=["1.1.1.1"], cache=cache
@@ -138,14 +251,8 @@ class TestGetDnskey(unittest.TestCase):
 
 
 class TestTestDnssec(unittest.TestCase):
-    @staticmethod
-    def _fresh_cache():
-        from expiringdict import ExpiringDict
-
-        return ExpiringDict(max_len=10, max_age_seconds=60)
-
     def testCacheHitTrue(self):
-        cache = self._fresh_cache()
+        cache = _fresh_cache()
         cache["example.com"] = True
         with patch("checkdmarc.dnssec.get_dnskey") as mock_key:
             result = checkdmarc.dnssec.test_dnssec("example.com", cache=cache)
@@ -153,60 +260,74 @@ class TestTestDnssec(unittest.TestCase):
         mock_key.assert_not_called()
 
     def testCacheHitFalse(self):
-        cache = self._fresh_cache()
+        cache = _fresh_cache()
         cache["example.com"] = False
         result = checkdmarc.dnssec.test_dnssec("example.com", cache=cache)
         self.assertFalse(result)
 
     def testNoSignedRecordsReturnsFalse(self):
         """If no signed records validate across all rdatatypes, return False"""
-        # Each per-rdatatype query returns an answer of length != 2,
-        # which fails the rrset/rrsig pairing check and continues.
-        response = MagicMock()
-        response.answer = []
-        with patch("checkdmarc.dnssec.get_dnskey", return_value=MagicMock()):
-            with patch("dns.query.tcp", return_value=response):
-                result = checkdmarc.dnssec.test_dnssec(
-                    "example.com",
-                    nameservers=["1.1.1.1"],
-                    cache=self._fresh_cache(),
-                )
+        with (
+            patch("checkdmarc.dnssec.get_dnskey", return_value=MagicMock()),
+            patch("dns.query.tcp", return_value=_response()),
+        ):
+            result = checkdmarc.dnssec.test_dnssec(
+                "example.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
+            )
+        self.assertFalse(result)
+
+    def testNameChainReturnsFalseInsteadOfRaising(self):
+        """A chain of names is reported as unsigned rather than crashing
+
+        Regression test for issue #265. The signature check is deliberately
+        left unpatched: passing it a missing signature is exactly the bug, and
+        would surface here as an AttributeError.
+        """
+        with (
+            patch("checkdmarc.dnssec.get_dnskey", return_value=MagicMock()),
+            patch("dns.query.tcp", return_value=_response(*_cname_chain())),
+        ):
+            result = checkdmarc.dnssec.test_dnssec(
+                "aws.amazon.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
+            )
+        self.assertFalse(result)
+
+    def testUnsignedRecordReturnsFalse(self):
+        """A record with no signature alongside it is reported as unsigned"""
+        response = _response(
+            dns.rrset.from_text("example.com.", 300, "IN", "A", "192.0.2.1")
+        )
+        with (
+            patch("checkdmarc.dnssec.get_dnskey", return_value=MagicMock()),
+            patch("dns.query.tcp", return_value=response),
+        ):
+            result = checkdmarc.dnssec.test_dnssec(
+                "example.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
+            )
         self.assertFalse(result)
 
     def testInvalidSignatureReturnsFalse(self):
         """A bad signature (ValidationFailure) at every rdatatype reports
         DNSSEC as not validated, rather than propagating the exception."""
-        import dns.exception
-        import dns.rdatatype
-
-        rrset = MagicMock()
-        rrset.rdtype = dns.rdatatype.A
-        rrsig = MagicMock()
-        rrsig.rdtype = dns.rdatatype.RRSIG
-        response = MagicMock()
-        response.answer = [rrset, rrsig]
-
-        with patch("checkdmarc.dnssec.get_dnskey", return_value=MagicMock()):
-            with patch("dns.query.tcp", return_value=response):
-                with patch(
-                    "dns.dnssec.validate",
-                    side_effect=dns.exception.ValidationFailure("bad signature"),
-                ):
-                    result = checkdmarc.dnssec.test_dnssec(
-                        "example.com",
-                        nameservers=["1.1.1.1"],
-                        cache=self._fresh_cache(),
-                    )
+        response = _response(
+            dns.rrset.from_text("example.com.", 300, "IN", "A", "192.0.2.1"),
+            _rrsig("example.com.", "A"),
+        )
+        with (
+            patch("checkdmarc.dnssec.get_dnskey", return_value=MagicMock()),
+            patch("dns.query.tcp", return_value=response),
+            patch(
+                "dns.dnssec.validate",
+                side_effect=dns.exception.ValidationFailure("bad signature"),
+            ),
+        ):
+            result = checkdmarc.dnssec.test_dnssec(
+                "example.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
+            )
         self.assertFalse(result)
 
 
 class TestGetTlsaRecords(unittest.TestCase):
-    @staticmethod
-    def _fresh_cache():
-        from expiringdict import ExpiringDict
-
-        return ExpiringDict(max_len=10, max_age_seconds=60)
-
     def testNoNameserversRaises(self):
         """An empty nameservers list raises ValueError"""
         self.assertRaises(
@@ -214,87 +335,108 @@ class TestGetTlsaRecords(unittest.TestCase):
             checkdmarc.dnssec.get_tlsa_records,
             "mail.example.com",
             nameservers=[],
-            cache=self._fresh_cache(),
+            cache=_fresh_cache(),
         )
 
     def testCacheHit(self):
-        cache = self._fresh_cache()
-        checkdmarc.dnssec.TLSA_CACHE["_25._tcp.mail.example.com"] = ["cached"]
-        try:
+        """A cached result is returned from the cache the caller passed in
+
+        The lookup must read the caller's cache, not the module-level one, and
+        must not reach the network to do it.
+        """
+        cache = _fresh_cache()
+        cache["_25._tcp.mail.example.com"] = ["cached"]
+        with patch("dns.query.tcp") as query:
             result = checkdmarc.dnssec.get_tlsa_records(
-                "mail.example.com",
-                nameservers=["1.1.1.1"],
-                cache=cache,
+                "mail.example.com", nameservers=["1.1.1.1"], cache=cache
             )
-            self.assertEqual(result, ["cached"])
+        self.assertEqual(result, ["cached"])
+        self.assertFalse(query.called)
+
+    def testModuleCacheNotConsultedWhenCallerPassesOne(self):
+        """A stale module-level entry must not leak into a caller's own cache"""
+        checkdmarc.dnssec.TLSA_CACHE["_25._tcp.mail.example.com"] = ["stale"]
+        try:
+            with patch("dns.query.tcp", return_value=_response()):
+                result = checkdmarc.dnssec.get_tlsa_records(
+                    "mail.example.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
+                )
+            self.assertEqual(result, [])
         finally:
             checkdmarc.dnssec.TLSA_CACHE.pop("_25._tcp.mail.example.com", None)
 
-    def testFewerThanTwoAnswersReturnsEmpty(self):
-        """An answer of length != 2 returns an empty list"""
-        response = MagicMock()
-        response.answer = []
-        with patch("dns.query.tcp", return_value=response):
+    def testNoRecordsReturnsEmpty(self):
+        """An answer with no TLSA records returns an empty list"""
+        with patch("dns.query.tcp", return_value=_response()):
             result = checkdmarc.dnssec.get_tlsa_records(
-                "mail.example.com",
-                nameservers=["1.1.1.1"],
-                cache=self._fresh_cache(),
+                "mail.example.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
+            )
+        self.assertEqual(result, [])
+
+    def testNameChainReturnsEmptyInsteadOfRaising(self):
+        """A chain of names returns no TLSA records rather than crashing
+
+        The same missing-signature bug as issue #265, on the TLSA path. The
+        signature check is left unpatched so the bug would surface here.
+        """
+        with patch("dns.query.tcp", return_value=_response(*_cname_chain())):
+            result = checkdmarc.dnssec.get_tlsa_records(
+                "mail.example.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
+            )
+        self.assertEqual(result, [])
+
+    def testUnsignedTlsaRecordsReturnsEmpty(self):
+        """TLSA records with no signature are not reported"""
+        rrset = dns.rrset.from_text(
+            "_25._tcp.mail.example.com.", 300, "IN", "TLSA", TLSA_RDATA
+        )
+        with patch("dns.query.tcp", return_value=_response(rrset)):
+            result = checkdmarc.dnssec.get_tlsa_records(
+                "mail.example.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
             )
         self.assertEqual(result, [])
 
     def testNoDnskeyReturnsEmpty(self):
         """TLSA records present but no DNSKEY to verify them returns an empty list"""
-        import dns.rdatatype
-
-        rrset = MagicMock()
-        rrset.rdtype = dns.rdatatype.TLSA
-        rrsig = MagicMock()
-        rrsig.rdtype = dns.rdatatype.RRSIG
-        response = MagicMock()
-        response.answer = [rrset, rrsig]
-        with patch("dns.query.tcp", return_value=response):
-            with patch("checkdmarc.dnssec.get_dnskey", return_value=None):
-                result = checkdmarc.dnssec.get_tlsa_records(
-                    "mail.example.com",
-                    nameservers=["1.1.1.1"],
-                    cache=self._fresh_cache(),
-                )
+        response = _response(
+            dns.rrset.from_text(
+                "_25._tcp.mail.example.com.", 300, "IN", "TLSA", TLSA_RDATA
+            ),
+            _rrsig("_25._tcp.mail.example.com.", "TLSA"),
+        )
+        with (
+            patch("dns.query.tcp", return_value=response),
+            patch("checkdmarc.dnssec.get_dnskey", return_value=None),
+        ):
+            result = checkdmarc.dnssec.get_tlsa_records(
+                "mail.example.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
+            )
         self.assertEqual(result, [])
 
     def testTlsaRecordsExtracted(self):
         """A signed TLSA RRset is decoded and cached"""
-        import dns.rdatatype
-
-        rrset = MagicMock()
-        rrset.rdtype = dns.rdatatype.TLSA
-
-        # Simple stand-in for a TLSA RR whose str() is the parsed record text.
-        class _StubRr:
-            def __str__(self) -> str:
-                return "3 1 1 abc123"
-
-        rr_item = _StubRr()
-        rrset.items = {rr_item: None}
-        rrsig = MagicMock()
-        rrsig.rdtype = dns.rdatatype.RRSIG
-        response = MagicMock()
-        response.answer = [rrset, rrsig]
-        with patch("dns.query.tcp", return_value=response):
-            with patch("checkdmarc.dnssec.get_dnskey", return_value=MagicMock()):
-                with patch("dns.dnssec.validate", return_value=None):
-                    result = checkdmarc.dnssec.get_tlsa_records(
-                        "mail.example.com",
-                        nameservers=["1.1.1.1"],
-                        cache=self._fresh_cache(),
-                    )
-        self.assertEqual(result, ["3 1 1 abc123"])
+        cache = _fresh_cache()
+        response = _response(
+            dns.rrset.from_text(
+                "_25._tcp.mail.example.com.", 300, "IN", "TLSA", TLSA_RDATA
+            ),
+            _rrsig("_25._tcp.mail.example.com.", "TLSA"),
+        )
+        with (
+            patch("dns.query.tcp", return_value=response),
+            patch("checkdmarc.dnssec.get_dnskey", return_value=MagicMock()),
+            patch("dns.dnssec.validate", return_value=None),
+        ):
+            result = checkdmarc.dnssec.get_tlsa_records(
+                "mail.example.com", nameservers=["1.1.1.1"], cache=cache
+            )
+        self.assertEqual(result, [TLSA_RDATA])
+        self.assertEqual(cache["_25._tcp.mail.example.com"], [TLSA_RDATA])
 
     def testQueryExceptionReturnsEmpty(self):
         with patch("dns.query.tcp", side_effect=OSError("boom")):
             result = checkdmarc.dnssec.get_tlsa_records(
-                "mail.example.com",
-                nameservers=["1.1.1.1"],
-                cache=self._fresh_cache(),
+                "mail.example.com", nameservers=["1.1.1.1"], cache=_fresh_cache()
             )
         self.assertEqual(result, [])
 


### PR DESCRIPTION
Fixes #265.

## The bug

`checkdmarc.check_domains(["aws.amazon.com"], skip_tls=True, nameservers=["1.1.1.1"])` fails with:

```
File "checkdmarc/dnssec.py", line 168, in test_dnssec
    dns.dnssec.validate(rrset, rrsig, key)
File ".../dns/dnssec.py", line 457, in _validate
    rrsigname = rrsigset.name
AttributeError: 'NoneType' object has no attribute 'name'
```

The DNSSEC code decided what an answer contained by counting the record sets in it — a two-record answer was assumed to be one record plus its signature. A name that points at another name breaks that assumption, because the answer holds every link in the chain and none of them is a signature. The missing signature reached the validator, and the error escaped `check_domains()` because `AttributeError` is not one of the types the lookup catches.

For `aws.amazon.com` via 1.1.1.1:

| query | answer record sets |
|---|---|
| DNSKEY | CNAME, CNAME — two records, no signature, crash |
| MX | CNAME, CNAME — same |
| A | CNAME, CNAME, A — three records, silently skipped |

## The fix

Records are picked out of an answer by name and type, with the signature matched to the type it covers, so a record is never paired with a signature belonging to something else or with no signature at all. One helper, `_find_record_and_signature()`, replaces the record-counting in all three places it appeared:

- **`test_dnssec()`** — where the reported crash happened.
- **`get_dnskey()`** — took the first record of *any* type in a DNSKEY answer as the key. For a chain of names that meant returning a CNAME dressed up as a key, so the `key is None` shortcut never fired and the base domain was never checked. It now falls back to the base domain, exactly as it already did for an empty answer.
- **`get_tlsa_records()`** — could crash the same way for a mail host whose name points at another name. The DNSKEY lookup also moved after the record check, so an unsigned TLSA answer no longer triggers a pointless extra query.

## Two cache bugs in the same functions

Found while verifying the above, and fixed here since they sit in the code being changed. Neither is a crash; both defeat the `cache` parameter. Default behaviour is unchanged, since `cache` defaults to the same module-level caches.

- `get_dnskey()`'s base-domain fallback did not pass the caller's cache along, so it wrote to the module-level cache instead. A caller supplying their own cache got an empty one back, and results leaked between callers.
- `get_tlsa_records()` wrote to the caller's cache but always read from the module-level one, so a caller's cached entries were never used and every lookup re-queried the network.

## Verification

Against real DNS: `aws.amazon.com` and `bka.de` (both from the issue) now return `False`, cross-checked with `dig` — neither publishes a DNSKEY. `fbi.gov`, `cloudflare.com`, `ietf.org`, `nist.gov`, `paypal.com`, `icann.org` and `isc.org` still return `True`; `google.com` and `mail.ru` correctly return `False`.

Every new regression test fails against the unfixed code with the exact reported `AttributeError`, and passes with the fix.

The tests are rebuilt on real dnspython record sets instead of `MagicMock`s. The old mocks could not express a record's name or the type a signature covers, which is why this shape of answer went unnoticed. One existing test had been written *around* the TLSA cache bug — seeding the module-level cache directly — which is what kept it invisible.

`checkdmarc/dnssec.py` is at 98% coverage. Version bumped to 5.17.4 with a CHANGELOG entry.

## Expected CI failure

**The `ruff check` step will fail, for reasons that predate this branch.** There is no `[tool.ruff]` section in `pyproject.toml` and CI installs `--upgrade ruff`, so ruff 0.16's expanded default rule set now flags a large backlog across the repo (`LOG015`, `UP009`, `SIM117`, `TRY201`, and others). `main` currently reports 194 such errors; this branch reports 188. This PR adds none — `checkdmarc/dnssec.py` goes from 12 to 11, and `tests/test_dnssec.py` from 5 to 0. That cleanup is deliberately left to a follow-up PR.

`pyright` is clean repo-wide. `tests/test_spf.py::testIncludeMissingSPF` fails locally on `main` too and is resolver-dependent, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)