### PR TITLE
Require cryptography>=50.0.0 and drop the version cap (GHSA-g6cj-pr64-35w5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 5.17.5
+
+### Security
+
+- Require `cryptography>=50.0.0` and remove the `<49.0` cap so installs get the fix for the PKCS#7 decryption padding oracle ([GHSA-g6cj-pr64-35w5](https://github.com/advisories/GHSA-g6cj-pr64-35w5)). checkdmarc does not use PKCS#7 decryption, but the old range could never resolve a patched version
+
+### Changed
+
+- Raise the `pyopenssl` floor to `>=26.4.0`. checkdmarc no longer imports pyOpenSSL — certificate handling uses `cryptography.x509` directly — but the dependency is kept for one release so upgrades also move any leftover pyOpenSSL to a version compatible with `cryptography` 50. It will be removed in the next release
+
+### Fixed
+
+- Update the network variant of the missing-include-domain SPF test to expect the `Error when processing` warning prefix introduced in 5.17.2; only the mocked variant was updated at the time, so the network test failed on every run
+
 ## 5.17.4
 
 ### Fixed

--- a/checkdmarc/_constants.py
+++ b/checkdmarc/_constants.py
@@ -19,7 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-__version__ = "5.17.4"
+__version__ = "5.17.5"
 
 OS = platform.system()
 OS_RELEASE = platform.release()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,13 @@ classifiers = [
 ]
 dependencies = [
     "dnspython>=2.0.0",
-    "cryptography>=48.0.1,<49.0",
-    "pyopenssl>=24.2.1",
+    "cryptography>=50.0.0",
+    # checkdmarc no longer imports pyopenssl; certificate handling uses
+    # cryptography.x509 directly. This floor is kept for one release so that
+    # upgrading checkdmarc also upgrades any leftover pyOpenSSL to a version
+    # compatible with cryptography 50 (older pyOpenSSL breaks at import
+    # against it). Remove this dependency in the release after 5.17.5.
+    "pyopenssl>=26.4.0",
     "pem>=23.1.0",
     "expiringdict>=1.1.4",
     "publicsuffixlist>=0.10.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dnspython>=2.0.0
-cryptography>=48.0.1,<49.0
+cryptography>=50.0.0
 pem>=23.1.0
 expiringdict>=1.1.4
 pyleri>=1.3.2

--- a/tests/test_spf.py
+++ b/tests/test_spf.py
@@ -63,8 +63,9 @@ class Test(unittest.TestCase):
         spf_record = "v=spf1 include:example.doesnotexist ~all"
         domain = "example.com"
         results = checkdmarc.spf.parse_spf_record(spf_record, domain)
-        self.assertTrue(
-            "example.doesnotexist: The domain does not exist." in results["warnings"]
+        self.assertIn(
+            "Error when processing example.doesnotexist: The domain does not exist.",
+            results["warnings"],
         )
         self.assertEqual(results["dns_lookups"], 1)
 


### PR DESCRIPTION
## Summary

- Require `cryptography>=50.0.0` and remove the `<49.0` cap in `pyproject.toml` and `requirements.txt`, resolving the open Dependabot alerts for [GHSA-g6cj-pr64-35w5](https://github.com/advisories/GHSA-g6cj-pr64-35w5) (PKCS#7 decryption padding oracle, patched in cryptography 50.0.0). checkdmarc does not use PKCS#7 decryption, so it was not itself affected — but the old range could never resolve a patched version.
- The cap only ever existed so cryptography could co-install with pyOpenSSL 26.2.0 (which declared `cryptography<49`). checkdmarc no longer imports pyOpenSSL at all — certificate handling uses `cryptography.x509` directly — so the cap has no remaining reason to exist.
- Keep the `pyopenssl` dependency for one release with its floor raised to `>=26.4.0` (the first release compatible with cryptography 50), so upgrading checkdmarc also moves any leftover pyOpenSSL forward instead of leaving an install that breaks at import. It will be removed in the release after 5.17.5.
- Fix `testIncludeMissingSPF`, which still asserted the warning text from before #256 added the `Error when processing` prefix; only the mocked twin was updated at the time, so the network variant failed on every run.
- Start the 5.17.5 changelog section and bump the version constant.

## Verification

- Clean resolve installs cryptography 50.0.0 + pyOpenSSL 26.4.0; `pip check` reports no broken requirements
- Full test suite against the resolved versions: 460 passed, 0 failed
- `ruff check` and `ruff format --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)