### PR TITLE
Upload test results via codecov-action@v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,11 @@ jobs:
         # Feeds Codecov Test Analytics (flaky-test detection, per-test
         # history). Runs even on test failure so failed cases still get
         # reported. Uses the same CODECOV_TOKEN as the coverage upload.
+        # Same action as the coverage upload with report_type switching
+        # the payload; it replaces the deprecated test-results-action.
         if: ${{ !cancelled() && matrix.python-version == '3.12' }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./junit.xml


### PR DESCRIPTION
codecov/test-results-action@v1 printed a deprecation notice during the 5.17.5 release run, pointing at its replacement: a second invocation of `codecov/codecov-action@v5` with `report_type: test_results`.

This switches the Test Analytics upload step accordingly, keeping the same token, junit.xml input, and `!cancelled()` guard so failed test cases are still reported.

Verified against the codecov-action README: `report_type` accepts `test_results` / `coverage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)