### PR TITLE
Update GitHub Actions to their latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
     name: Lint, type-check, and build checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -68,10 +68,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
@@ -99,7 +99,7 @@ jobs:
         # Same action as the coverage upload with report_type switching
         # the payload; it replaces the deprecated test-results-action.
         if: ${{ !cancelled() && matrix.python-version == '3.12' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,10 +24,10 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -46,13 +46,13 @@ jobs:
           make html
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/build/html
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -49,7 +49,7 @@ jobs:
         run: python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -65,7 +65,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -80,10 +80,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Update the GitHub Actions used by the workflows to their latest major versions: `checkout` v7, `setup-python` v7, `codecov-action` v7, `upload-artifact` v7, `download-artifact` v8, `configure-pages` v6, `upload-pages-artifact` v5, and `deploy-pages` v5. All now run on Node.js 24; no workflow behavior changes
+
 ## 5.17.5
 
 ### Security


### PR DESCRIPTION
Bumps every action used by the workflows to its latest major version:

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-python | v5 | v7 |
| codecov/codecov-action | v5 | v7 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/configure-pages | v5 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |

`pypa/gh-action-pypi-publish` stays on `release/v1`, which already floats to the latest v1.x (currently v1.14.2) — that is the pinning style pypa recommends.

## Breaking-change review

I read the release notes for every intervening major of each action; none of the breaking changes affect these workflows:

- **Node.js 24 runtime** (all of them): fine on GitHub-hosted `ubuntu-latest` runners, which are well past the required runner v2.327.1.
- **setup-python v7** removed the `pip-install` input — not used here (`python-version` and `cache: pip` are unchanged).
- **codecov-action v6/v7** are runtime-only bumps; the `token`, `files`, `fail_ci_if_error`, and `report_type` inputs are unchanged.
- **download-artifact v5** changed the extraction path only for single-artifact downloads **by ID**; release.yml downloads by name, whose behavior is unchanged. v8's new digest-mismatch-errors default is a security improvement with no workflow change needed.
- **upload-pages-artifact v4** stopped including hidden (dot-prefixed) files — the Sphinx HTML output has no load-bearing dotfiles (`.buildinfo` is only for incremental rebuilds, and artifact-based Pages deployments don't run Jekyll, so no `.nojekyll` is needed).
- **checkout v7** blocks checking out fork PR heads in `pull_request_target`/`workflow_run` triggers — neither trigger is used here.

Also checked open Dependabot alerts and PRs per AGENTS.md: none open.

A `## Unreleased` CHANGELOG section records the change for the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)