### PR TITLE
Re-add RFC 6652 SPF modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- SPF: the RFC 6652 reporting modifiers `ra=`, `rp=`, and `rr=` are once again added as valid modifiers. Their values are validated against RFC 6652 §3: `ra=` is a local-part (RFC 5322 §3.4.1), `rp=` is an integer 0–100 per erratum 6579's corrected ABNF, and `rr=` is a colon-separated list of `all`/`e`/`f`/`s`/`n`. They are detected as modifiers and their syntax is checked as per spec.
+- SPF: the RFC 6652 reporting modifiers `ra=`, `rp=`, and `rr=`, added in 5.8.0 and removed later, are recognized again; their values are validated against RFC 6652 §3 (`rp=` per erratum 6579) and surfaced in the parsed result as `ra`, `rp`, and `rr` next to `exp`, and a malformed value is warned about and ignored instead of failing the record. Warnings also cover the two RFC 6652 §3 semantic rules — `rp=` and `rr=` do nothing without `ra=`, and `ra=` is ignored in a record reached through an `include` — and `exp=` and these modifiers are now honored after `all` in any order
 
 ## 6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- SPF: the RFC 6652 reporting modifiers `ra=`, `rp=`, and `rr=` are once again added as valid modifiers. Their values are validated against RFC 6652 §3: `ra=` is a local-part (RFC 5322 §3.4.1), `rp=` is an integer 0–100 per erratum 6579's corrected ABNF, and `rr=` is a colon-separated list of `all`/`e`/`f`/`s`/`n`. They are detected as modifiers and their syntax is checked as per spec.
+
 ## 6.0.0
 
 An RFC conformance audit compared every module line-by-line against its

--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -75,11 +75,28 @@ SPF_MECHANISM_NAMES = frozenset(
     {"all", "include", "a", "mx", "ptr", "ip4", "ip6", "exists"}
 )
 
-# Modifiers defined by RFC 6652 (SPF authorization for the PRA identity) that
-# were removed when RFC 7208 superseded it. They are still ignored like any
-# unknown modifier, but with a deprecation warning pointing to the spec
-# change.
-DEPRECATED_SPF_MODIFIERS = frozenset({"ra", "rp", "rr"})
+# Reporting modifiers defined by RFC 6652 (SPF Authentication Failure
+# Reporting Using the Abuse Reporting Format). Unlike the SPF mechanisms
+# (RFC 7208) these are not part of RFC 7208's grammar, but RFC 7208 § 6
+# requires unrecognized modifiers to be ignored so that extensions like this
+# keep working, and RFC 7208 § 10.1.2 recommends RFC 6652 for failure
+# feedback. RFC 6652 is a current Proposed Standard, obsoleted by nothing.
+RFC6652_MODIFIERS = frozenset({"ra", "rp", "rr"})
+
+# RFC 6652 § 3: the rr= (Requested Reports) modifier is a colon-separated
+# list of these condition tokens. The default, when rr= is absent, is "all".
+RFC6652_RR_TYPES = frozenset({"all", "e", "f", "s", "n"})
+
+# erratum 6579 (Held for Document Update, Technical) corrects RFC 6652 § 3's
+# published rp= ABNF, which wrongly required a "/"-separated pair, to
+# an integer from 0 to 100 inclusive. We validate against the corrected
+# ABNF: the literal "100", or one or two digits (0-99).
+RP_REGEX = re.compile(r"100|[0-9]{1,2}")
+
+# RFC 5322 § 3.4.1 local-part as a dot-atom: atext runs joined by single dots,
+# with no leading/trailing dot and no consecutive dots.
+ATEXT = r"[A-Za-z0-9!#$%&'*+\-/=?^_`{|}~]"
+LOCAL_PART_REGEX = re.compile(rf"{ATEXT}+(?:\.{ATEXT}+)*")
 
 # toplabel per RFC 7208 section 12: letters and digits with at least one
 # letter, or a hyphenated label that starts and ends with a letter or digit.
@@ -240,6 +257,9 @@ class ParsedSPFRecord(TypedDict):
     ]
     redirect: SPFRedirect | None
     exp: str | None
+    ra: str | None
+    rp: str | None
+    rr: list[str] | None
     all: str
 
 
@@ -622,6 +642,7 @@ def parse_spf_record(
     retries: int = DEFAULT_DNS_MAX_RETRIES,
     syntax_error_marker: str = SYNTAX_ERROR_MARKER,
     _include_cache: dict[str, SPFRecordResults] | None = None,
+    _included: bool = False,
 ) -> SPFRecordResults:
     """
     Parses an SPF record, including resolving ``a``, ``mx``, and ``include`` mechanisms
@@ -638,6 +659,8 @@ def parse_spf_record(
         timeout (float): number of seconds to wait for an answer from DNS
         retries (int): The number of times to retry on timeout or other transient errors
         syntax_error_marker (str): The marker for pointing out syntax errors
+        _included (bool): Internal flag: this record was reached by following
+            an ``include``
 
     Returns:
         dict: A ``dict`` with the following keys:
@@ -736,6 +759,9 @@ def parse_spf_record(
         "mechanisms": [],
         "redirect": None,
         "exp": None,
+        "ra": None,
+        "rp": None,
+        "rr": None,
         "all": "neutral",
     }
 
@@ -744,6 +770,7 @@ def parse_spf_record(
     error = None
     exp_seen = False
     redirect_seen = False
+    ra_seen = False
 
     def _count_dns_lookups(count: int = 1) -> None:
         """Add DNS-querying terms to the total and enforce the 10-term limit.
@@ -858,6 +885,96 @@ def parse_spf_record(
         except DNSException as e:
             warnings.append(f"Failed to get TXT records at exp value {exp_value}: {e}")
 
+    def _parse_rfc6652_value(
+        name: str, raw_value: str
+    ) -> tuple[str | list[str] | None, str | None]:
+        """Validate an RFC 6652 § 3 modifier value.
+
+        Returns ``(parsed_value, error_message)``. ``parsed_value`` is the
+        normalized value (a string for ra/rp, a list of tokens for rr), or
+        None when the value is malformed. ``error_message`` is None when the
+        value is valid.
+
+        A malformed value is reported as a warning, not an ``SPFSyntaxError``:
+        """
+        if name == "ra":
+            # RFC 6652 § 3: ra= is a local-part (RFC 5322 § 3.4.1). The
+            # verifier appends "@" + the SPF domain, so a value that is
+            # already an address (contains "@") is malformed.
+            if raw_value == "":
+                return None, (
+                    "The ra modifier is missing a value; it was ignored (RFC 6652 § 3)."
+                )
+            if LOCAL_PART_REGEX.fullmatch(raw_value) is None:
+                return None, (
+                    f"The ra modifier value {raw_value} is not a valid local-part "
+                    "(RFC 5322 § 3.4.1); it was ignored (RFC 6652 § 3)."
+                )
+            return raw_value, None
+        if name == "rp":
+            value = raw_value.lower()
+            if value == "":
+                return None, (
+                    "The rp modifier is missing a value; it was ignored (RFC 6652 § 3)."
+                )
+            if RP_REGEX.fullmatch(value) is None:
+                return None, (
+                    f"The rp modifier value {raw_value} is not an integer "
+                    "from 0 to 100 (RFC 6652 § 3, erratum 6579); it was ignored."
+                )
+            return value, None
+        value = raw_value.lower()
+        if value == "":
+            return None, (
+                "The rr modifier is missing a value; it was ignored (RFC 6652 § 3)."
+            )
+        tokens = value.split(":")
+        if not all(t in RFC6652_RR_TYPES for t in tokens):
+            return None, (
+                f"The rr modifier value {raw_value} is not a colon-separated "
+                "list of the tokens all, e, f, s, n (RFC 6652 § 3); it was ignored."
+            )
+        return tokens, None
+
+    def _record_rfc6652_modifier(name: str, raw_value: str) -> None:
+        """Validate an RFC 6652 modifier and store its parsed value.
+
+        A malformed value is warned about and ignored. A repeat modifier is
+        warned about and the first occurrence is kept.
+        """
+        nonlocal ra_seen
+        parsed_value, error = _parse_rfc6652_value(name, raw_value)
+        if error is not None:
+            warnings.append(error)
+            return
+        if parsed[name] is not None:
+            warnings.append(
+                f"The {name} modifier appeared more than once; only the first "
+                "value is kept (RFC 6652 § 3)."
+            )
+            return
+        parsed[name] = parsed_value
+        if name == "ra":
+            ra_seen = True
+
+    def _check_rfc6652_semantics() -> None:
+        """Warn on the two RFC 6652 § 3 semantic rules.
+
+        - An ra= modifier in a record reached by an include mechanism MUST be
+          ignored (it cannot solicit reports for the including domain).
+        - Without an ra= tag, rp= and rr= have no effect.
+        """
+        if ra_seen and _included:
+            warnings.append(
+                "The ra modifier was ignored because this record was reached "
+                "through an include mechanism (RFC 6652 § 3)."
+            )
+        if not ra_seen and (parsed["rp"] is not None or parsed["rr"] is not None):
+            warnings.append(
+                "The rp and rr modifiers have no effect without an ra modifier "
+                "(RFC 6652 § 3)."
+            )
+
     # Handle the text after the first all mechanism. Evaluation stops at the
     # first matching mechanism (RFC 7208 section 4.6.2), so terms after all
     # are never used and are not processed, counted, or listed; only an exp
@@ -895,7 +1012,25 @@ def parse_spf_record(
                     "The record contains multiple all mechanisms; only the "
                     "first one is used (RFC 7208 § 4.6.2)."
                 )
-            if len(extra_all_tokens) < len(after_tokens):
+            # RFC 6652 § 3 reporting modifiers may appear after all, so honor them like
+            # any other modifier. Anything else after all is ignored.
+            unknown_after_all: list[str] = []
+            for token in after_tokens:
+                if ALL_TERM_REGEX.fullmatch(token) is not None:
+                    continue
+                term_match = SPF_MECHANISM_REGEX.fullmatch(token)
+                if (
+                    term_match is not None
+                    and term_match.group(3) == "="
+                    and (term_match.group(1) or "") == ""
+                    and term_match.group(2).lower() in RFC6652_MODIFIERS
+                ):
+                    _record_rfc6652_modifier(
+                        term_match.group(2).lower(), term_match.group(4) or ""
+                    )
+                else:
+                    unknown_after_all.append(token)
+            if unknown_after_all:
                 warnings.append(
                     "Any text after the all mechanism other than an exp modifier is ignored."
                 )
@@ -936,16 +1071,11 @@ def parse_spf_record(
             elif name == "exp":
                 if value == "":
                     raise SPFSyntaxError("The exp modifier is missing a value")
-            elif name in DEPRECATED_SPF_MODIFIERS:
-                # ra=, rp=, and rr= were defined by RFC 6652 (SPF
-                # authorization for the PRA identity) but were dropped when
-                # RFC 7208 replaced RFC 4408. They are no longer defined SPF
-                # modifiers, so like any other unknown modifier they are
-                # ignored per RFC 7208 section 6 - with a specific warning
-                warnings.append(
-                    f"The {name} modifier was defined by RFC 6652 and removed "
-                    f"in RFC 7208. It was ignored (RFC 7208 § 6)."
-                )
+            elif name in RFC6652_MODIFIERS:
+                # ra=, rp=, and rr= are reporting modifiers defined by RFC 6652
+                # § 3. Their validation needs no DNS work, so they are not
+                # carried into the second pass.
+                _record_rfc6652_modifier(name, raw_value)
                 continue
             else:
                 # RFC 7208 section 6: "Unrecognized modifiers MUST be
@@ -1250,6 +1380,7 @@ def parse_spf_record(
                         timeout=timeout,
                         retries=retries,
                         _include_cache=_include_cache,
+                        _included=_included,
                     )
                     parsed["all"] = redirected_spf["parsed"]["all"]
                     mechanism_dns_lookups += redirected_spf["dns_lookups"]
@@ -1376,6 +1507,7 @@ def parse_spf_record(
                     timeout=timeout,
                     retries=retries,
                     _include_cache=_include_cache,
+                    _included=True,
                 )
                 _include_cache[value] = include
                 _count_dns_lookups(include["dns_lookups"])
@@ -1457,6 +1589,9 @@ def parse_spf_record(
                 parsed["mechanisms"].append(failed_mechanism)
                 _count_void_dns_lookups()
             warnings.append(f"Error when processing {value or domain}: {warning!s}")
+
+    # RFC 6652 § 3 semantic checks run after every modifier has been recorded.
+    _check_rfc6652_semantics()
 
     if error:
         error_result: ParsedSPFRecordError = {

--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -258,7 +258,7 @@ class ParsedSPFRecord(TypedDict):
     redirect: SPFRedirect | None
     exp: str | None
     ra: str | None
-    rp: str | None
+    rp: int | None
     rr: list[str] | None
     all: str
 
@@ -887,15 +887,19 @@ def parse_spf_record(
 
     def _parse_rfc6652_value(
         name: str, raw_value: str
-    ) -> tuple[str | list[str] | None, str | None]:
+    ) -> tuple[str | int | list[str] | None, str | None]:
         """Validate an RFC 6652 § 3 modifier value.
 
         Returns ``(parsed_value, error_message)``. ``parsed_value`` is the
-        normalized value (a string for ra/rp, a list of tokens for rr), or
-        None when the value is malformed. ``error_message`` is None when the
-        value is valid.
+        normalized value (a string for ra, an integer for rp, a list of
+        tokens for rr), or None when the value is malformed.
+        ``error_message`` is None when the value is valid.
 
-        A malformed value is reported as a warning, not an ``SPFSyntaxError``:
+        A malformed value is reported as a warning, not an
+        ``SPFSyntaxError``, because no specification makes it a permanent
+        error: RFC 6652 does not, and to an implementation that does not know
+        RFC 6652 these are unknown modifiers, which RFC 7208 § 6 requires to
+        be ignored.
         """
         if name == "ra":
             # RFC 6652 § 3: ra= is a local-part (RFC 5322 § 3.4.1). The
@@ -922,7 +926,7 @@ def parse_spf_record(
                     f"The rp modifier value {raw_value} is not an integer "
                     "from 0 to 100 (RFC 6652 § 3, erratum 6579); it was ignored."
                 )
-            return value, None
+            return int(value), None
         value = raw_value.lower()
         if value == "":
             return None, (
@@ -939,8 +943,9 @@ def parse_spf_record(
     def _record_rfc6652_modifier(name: str, raw_value: str) -> None:
         """Validate an RFC 6652 modifier and store its parsed value.
 
-        A malformed value is warned about and ignored. A repeat modifier is
-        warned about and the first occurrence is kept.
+        Call this in the order the modifiers appear in the record: a malformed
+        value is warned about and ignored, and when the same modifier appears
+        more than once the first occurrence is the one that is kept.
         """
         nonlocal ra_seen
         parsed_value, error = _parse_rfc6652_value(name, raw_value)
@@ -948,9 +953,14 @@ def parse_spf_record(
             warnings.append(error)
             return
         if parsed[name] is not None:
+            # RFC 6652 says nothing about a reporting modifier appearing more
+            # than once, and RFC 7208 § 6 makes only redirect and exp a
+            # permerror when repeated; every other modifier is ignored "no
+            # matter where, or how often" it appears. So keep the first value,
+            # ignore the rest, and warn.
             warnings.append(
                 f"The {name} modifier appeared more than once; only the first "
-                "value is kept (RFC 6652 § 3)."
+                "value is kept."
             )
             return
         parsed[name] = parsed_value
@@ -977,63 +987,71 @@ def parse_spf_record(
 
     # Handle the text after the first all mechanism. Evaluation stops at the
     # first matching mechanism (RFC 7208 section 4.6.2), so terms after all
-    # are never used and are not processed, counted, or listed; only an exp
-    # modifier placed there is still honored.
+    # are never used and are not processed, counted, or listed. Modifiers may
+    # appear anywhere in a record (RFC 7208 section 6), so each token here is
+    # looked at on its own, in the order it was written: another all
+    # mechanism only feeds the "multiple all mechanisms" warning, an exp
+    # modifier is honored, an RFC 6652 reporting modifier is set aside and
+    # recorded once the first pass has read the terms before all, and
+    # anything else is reported as ignored text.
+    deferred_rfc6652_modifiers: list[tuple[str, str]] = []
     items_after_all: list[str] = AFTER_ALL_REGEX.findall(record)
     if len(items_after_all) > 0:
-        # Modifier names are case-insensitive (RFC 7208 section 4.6.1), so
-        # EXP= and Exp= must be recognized here too.
-        if items_after_all[0][:4].lower() == "exp=":
-            # RFC 7208 § 6.2 (exp modifier): The explanation string is
-            # evaluated at runtime (after result == fail) and may contain
-            # macros. It MUST NOT contribute to DNS lookup counting and
-            # SHOULD NOT be resolved during static parsing.
-            exp_value = items_after_all[0].split("=", 1)[1]
-            if exp_value.strip() == "":
-                raise SPFSyntaxError("The exp modifier is missing a value")
-            exp_tokens = exp_value.split(" ")
-            if len(exp_tokens) > 1:
-                warnings.append("No text should exist after the exp modifier value.")
-            exp_value = exp_tokens[0]
-            parsed["exp"] = exp_value
-            exp_seen = True
-            _check_exp_value(exp_value)
-        else:
-            after_tokens = items_after_all[0].split()
-            extra_all_tokens = [
-                token
-                for token in after_tokens
-                if ALL_TERM_REGEX.fullmatch(token) is not None
-            ]
-            if extra_all_tokens:
-                # RFC 7208 places no uniqueness constraint on all; the first
-                # match simply wins (section 4.6.2).
-                warnings.append(
-                    "The record contains multiple all mechanisms; only the "
-                    "first one is used (RFC 7208 § 4.6.2)."
-                )
-            # RFC 6652 § 3 reporting modifiers may appear after all, so honor them like
-            # any other modifier. Anything else after all is ignored.
-            unknown_after_all: list[str] = []
-            for token in after_tokens:
-                if ALL_TERM_REGEX.fullmatch(token) is not None:
-                    continue
-                term_match = SPF_MECHANISM_REGEX.fullmatch(token)
-                if (
-                    term_match is not None
-                    and term_match.group(3) == "="
-                    and (term_match.group(1) or "") == ""
-                    and term_match.group(2).lower() in RFC6652_MODIFIERS
-                ):
-                    _record_rfc6652_modifier(
-                        term_match.group(2).lower(), term_match.group(4) or ""
-                    )
-                else:
-                    unknown_after_all.append(token)
-            if unknown_after_all:
-                warnings.append(
-                    "Any text after the all mechanism other than an exp modifier is ignored."
-                )
+        extra_all_tokens: list[str] = []
+        ignored_after_all: list[str] = []
+        for token in items_after_all[0].split():
+            if ALL_TERM_REGEX.fullmatch(token) is not None:
+                extra_all_tokens.append(token)
+                continue
+            term_match = SPF_MECHANISM_REGEX.fullmatch(token)
+            if (
+                term_match is None
+                or term_match.group(3) != "="
+                or (term_match.group(1) or "") != ""
+            ):
+                # Not a modifier: a mechanism, a qualified modifier (which
+                # the RFC 7208 section 12 ABNF does not allow), or junk.
+                ignored_after_all.append(token)
+                continue
+            # Modifier names are case-insensitive (RFC 7208 section 4.6.1), so
+            # EXP= and Exp= must be recognized here too.
+            modifier_name = term_match.group(2).lower()
+            modifier_value = term_match.group(4) or ""
+            if modifier_name == "exp":
+                # RFC 7208 § 6.2 (exp modifier): The explanation string is
+                # evaluated at runtime (after result == fail) and may contain
+                # macros. It MUST NOT contribute to DNS lookup counting and
+                # SHOULD NOT be resolved during static parsing.
+                if modifier_value == "":
+                    raise SPFSyntaxError("The exp modifier is missing a value")
+                if exp_seen:
+                    # RFC 7208 § 6: an exp modifier that appears more than
+                    # once is a permerror, wherever the copies are.
+                    raise SPFSyntaxError("Multiple exp values are not permitted")
+                # The exp value keeps its original case because uppercase
+                # macro letters change how macros expand (RFC 7208 § 7.3).
+                parsed["exp"] = modifier_value
+                exp_seen = True
+                _check_exp_value(modifier_value)
+            elif modifier_name in RFC6652_MODIFIERS:
+                # Held back so that a modifier written both before and after
+                # all is recorded in the order the record lists it, and the
+                # earlier value wins.
+                deferred_rfc6652_modifiers.append((modifier_name, modifier_value))
+            else:
+                ignored_after_all.append(token)
+        if extra_all_tokens:
+            # RFC 7208 places no uniqueness constraint on all; the first
+            # match simply wins (section 4.6.2).
+            warnings.append(
+                "The record contains multiple all mechanisms; only the "
+                "first one is used (RFC 7208 § 4.6.2)."
+            )
+        if ignored_after_all:
+            warnings.append(
+                "Any text after the all mechanism other than an exp modifier "
+                "or an RFC 6652 reporting modifier is ignored."
+            )
 
     # Split the record into terms. Everything after the first all mechanism
     # was trimmed from grammar_record above.
@@ -1168,6 +1186,11 @@ def parse_spf_record(
                 if "%" not in value and value != "":
                     _maybe_warn_domain_spec(name, value)
         prepared_terms.append((qualifier, name, sep, value, raw_value))
+
+    # The RFC 6652 modifiers written after all come last in the record, so
+    # they are recorded after the first pass has read the ones before it.
+    for deferred_name, deferred_value in deferred_rfc6652_modifiers:
+        _record_rfc6652_modifier(deferred_name, deferred_value)
 
     # Second pass: process the validated terms, resolving DNS where needed
     # and enforcing the RFC 7208 section 4.6.4 lookup limits after every

--- a/checkdmarc/spf.py
+++ b/checkdmarc/spf.py
@@ -75,6 +75,12 @@ SPF_MECHANISM_NAMES = frozenset(
     {"all", "include", "a", "mx", "ptr", "ip4", "ip6", "exists"}
 )
 
+# Modifiers defined by RFC 6652 (SPF authorization for the PRA identity) that
+# were removed when RFC 7208 superseded it. They are still ignored like any
+# unknown modifier, but with a deprecation warning pointing to the spec
+# change.
+DEPRECATED_SPF_MODIFIERS = frozenset({"ra", "rp", "rr"})
+
 # toplabel per RFC 7208 section 12: letters and digits with at least one
 # letter, or a hyphenated label that starts and ends with a letter or digit.
 TOPLABEL_REGEX = re.compile(r"[a-z0-9]*[a-z][a-z0-9]*|[a-z0-9]+-[a-z0-9\-]*[a-z0-9]")
@@ -930,6 +936,17 @@ def parse_spf_record(
             elif name == "exp":
                 if value == "":
                     raise SPFSyntaxError("The exp modifier is missing a value")
+            elif name in DEPRECATED_SPF_MODIFIERS:
+                # ra=, rp=, and rr= were defined by RFC 6652 (SPF
+                # authorization for the PRA identity) but were dropped when
+                # RFC 7208 replaced RFC 4408. They are no longer defined SPF
+                # modifiers, so like any other unknown modifier they are
+                # ignored per RFC 7208 section 6 - with a specific warning
+                warnings.append(
+                    f"The {name} modifier was defined by RFC 6652 and removed "
+                    f"in RFC 7208. It was ignored (RFC 7208 § 6)."
+                )
+                continue
             else:
                 # RFC 7208 section 6: "Unrecognized modifiers MUST be
                 # ignored no matter where, or how often, they appear in a

--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -282,6 +282,9 @@ checkdmarc proton.me
                   ],
                   "redirect": null,
                   "exp": null,
+                  "ra": null,
+                  "rp": null,
+                  "rr": null,
                   "all": "softfail"
                 },
                 "warnings": []
@@ -289,6 +292,9 @@ checkdmarc proton.me
             ],
             "redirect": null,
             "exp": null,
+            "ra": null,
+            "rp": null,
+            "rr": null,
             "all": "softfail"
           },
           "warnings": []
@@ -296,6 +302,9 @@ checkdmarc proton.me
       ],
       "redirect": null,
       "exp": null,
+      "ra": null,
+      "rp": null,
+      "rr": null,
       "all": "softfail"
     }
   },

--- a/tests/test_spf.py
+++ b/tests/test_spf.py
@@ -1259,6 +1259,30 @@ class TestRFC7208Conformance(unittest.TestCase):
         mechanisms = [m["mechanism"] for m in result["parsed"]["mechanisms"]]
         self.assertIn("ip4", mechanisms)
 
+    def testRFC6652ModifiersDeprecatedWarning(self):
+        """ra=, rp=, rr= were valid under RFC 6652 but removed in RFC 7208;
+        they are ignored with a deprecation warning rather than the generic
+        unknown-modifier warning."""
+        for modifier in ("ra", "rp", "rr"):
+            with self.subTest(modifier=modifier):
+                result = checkdmarc.spf.parse_spf_record(
+                    f"v=spf1 {modifier}=x ip4:192.0.2.1 -all", "example.com"
+                )
+                warnings = result["warnings"]
+                self.assertTrue(
+                    any(
+                        modifier in w and "RFC 6652" in w and "RFC 7208" in w
+                        for w in warnings
+                    ),
+                    f"expected a deprecation warning for {modifier}=, got "
+                    f"{warnings}",
+                )
+                self.assertFalse(
+                    any(f"unknown modifier {modifier}" in w for w in warnings)
+                )
+                self.assertEqual(result["dns_lookups"], 0)
+                self.assertEqual(result["parsed"]["all"], "fail")
+
     def testQualifierOnModifierIsSyntaxError(self):
         """A qualifier on a modifier does not match the RFC 7208 section 12
         ABNF and raises SPFSyntaxError"""

--- a/tests/test_spf.py
+++ b/tests/test_spf.py
@@ -8,7 +8,11 @@ from unittest.mock import patch
 import dns.exception
 
 import checkdmarc.spf
-from checkdmarc.spf import ParsedSPFMXMechanism, SPFAMechanism
+from checkdmarc.spf import (
+    ParsedSPFMXMechanism,
+    SPFAMechanism,
+    SPFIncludeMechanism,
+)
 
 OFFLINE_MODE = os.environ.get("GITHUB_ACTIONS", "false").lower() == "true"
 
@@ -50,7 +54,8 @@ class Test(unittest.TestCase):
         rec = "v=spf1 ip4:213.5.39.110 -all MS=83859DAEBD1978F9A7A67D3"
         domain = "avd.dk"
         warning = (
-            "Any text after the all mechanism other than an exp modifier is ignored."
+            "Any text after the all mechanism other than an exp modifier or an "
+            "RFC 6652 reporting modifier is ignored."
         )
 
         parsed_record = checkdmarc.spf.parse_spf_record(rec, domain)
@@ -692,7 +697,8 @@ class Test(unittest.TestCase):
         rec = "v=spf1 ip4:213.5.39.110 -all MS=83859DAEBD1978F9A7A67D3"
         domain = "avd.dk"
         warning = (
-            "Any text after the all mechanism other than an exp modifier is ignored."
+            "Any text after the all mechanism other than an exp modifier or an "
+            "RFC 6652 reporting modifier is ignored."
         )
 
         with patch("checkdmarc.spf.query_dns", return_value=[]):
@@ -980,16 +986,29 @@ class TestSPFExpModifier(unittest.TestCase):
         )
 
     def testTextAfterExpValueWarns(self):
+        """Junk after an exp modifier that follows all is ignored text: the
+        exp value itself is still honored."""
         with patch("checkdmarc.spf.get_txt_records", return_value=["explanation"]):
             result = checkdmarc.spf.parse_spf_record(
                 "v=spf1 -all exp=exp.example extra", "example.com"
             )
-        self.assertTrue(
-            any(
-                "No text should exist after the exp modifier value" in w
-                for w in result["warnings"]
-            )
+        self.assertEqual(result["parsed"]["exp"], "exp.example")
+        self.assertIn(
+            "Any text after the all mechanism other than an exp modifier or an "
+            "RFC 6652 reporting modifier is ignored.",
+            result["warnings"],
         )
+
+    def testTwoExpModifiersAfterAllIsSyntaxError(self):
+        """RFC 7208 § 6: an exp modifier that appears more than once is a
+        permanent error, including when both copies follow the all
+        mechanism, where the second one used to be ignored as trailing
+        text."""
+        with self.assertRaises(checkdmarc.spf.SPFSyntaxError) as ctx:
+            checkdmarc.spf.parse_spf_record(
+                "v=spf1 -all exp=exp.example exp=other.example", "example.com"
+            )
+        self.assertIn("Multiple exp values are not permitted", str(ctx.exception))
 
 
 class TestSPFMacroValidation(unittest.TestCase):
@@ -1268,7 +1287,7 @@ class TestRFC7208Conformance(unittest.TestCase):
             "v=spf1 ip4:192.0.2.1 -all ra=postmaster rp=10 rr=e", "example.com"
         )
         self.assertEqual(result["parsed"]["ra"], "postmaster")
-        self.assertEqual(result["parsed"]["rp"], "10")
+        self.assertEqual(result["parsed"]["rp"], 10)
         self.assertEqual(result["parsed"]["rr"], ["e"])
         self.assertEqual(result["dns_lookups"], 0)
         self.assertEqual(result["parsed"]["all"], "fail")
@@ -1302,13 +1321,13 @@ class TestRFC7208Conformance(unittest.TestCase):
     def testRFC6652RpIntegerRange(self):
         """rp= is an integer 0-100 per the erratum 6579 corrected ABNF; any
         other value is warned about and ignored, not a syntax error."""
-        # Boundary values that are valid.
+        # Boundary values that are valid. They are surfaced as integers.
         for value in ("0", "100", "50"):
             with self.subTest(value=value):
                 result = checkdmarc.spf.parse_spf_record(
                     f"v=spf1 ra=postmaster rp={value} -all", "example.com"
                 )
-                self.assertEqual(result["parsed"]["rp"], value)
+                self.assertEqual(result["parsed"]["rp"], int(value))
                 self.assertEqual(result["warnings"], [])
         # Out-of-range / malformed values are ignored with a warning.
         for value in ("101", "-1", "abc", "1000"):
@@ -1354,7 +1373,7 @@ class TestRFC7208Conformance(unittest.TestCase):
             "v=spf1 rp=10 rr=e ip4:192.0.2.1 -all", "example.com"
         )
         # The values are still surfaced (they exist in the record)...
-        self.assertEqual(result["parsed"]["rp"], "10")
+        self.assertEqual(result["parsed"]["rp"], 10)
         self.assertEqual(result["parsed"]["rr"], ["e"])
         self.assertIsNone(result["parsed"]["ra"])
         # ...but a warning explains they have no effect.
@@ -1374,9 +1393,8 @@ class TestRFC7208Conformance(unittest.TestCase):
             result = checkdmarc.spf.parse_spf_record(
                 "v=spf1 include:other.example -all", "example.com"
             )
-        included = result["parsed"]["mechanisms"][0]
+        included = cast(SPFIncludeMechanism, result["parsed"]["mechanisms"][0])
         self.assertEqual(included["mechanism"], "include")
-        self.assertEqual(included["parsed"]["ra"], "postmaster")
         self.assertTrue(
             any(
                 "ra modifier was ignored" in w and "include mechanism" in w
@@ -1384,9 +1402,11 @@ class TestRFC7208Conformance(unittest.TestCase):
             ),
             f"expected an include-ignore warning for ra=, got {result['warnings']}",
         )
+        included_parsed = included["parsed"]
+        assert included_parsed is not None
         # The ra= value is surfaced for visibility even though it is ignored
         # by report generators.
-        self.assertEqual(included["parsed"]["ra"], "postmaster")
+        self.assertEqual(included_parsed["ra"], "postmaster")
 
     def testRFC6652RaNotIgnoredInRedirect(self):
         """A redirect target (not reached via include) keeps its ra= honored:
@@ -1419,6 +1439,72 @@ class TestRFC7208Conformance(unittest.TestCase):
                 )
                 self.assertEqual(result["dns_lookups"], 0)
                 self.assertEqual(result["parsed"]["all"], "fail")
+
+    def testRFC6652ModifiersWithNoValue(self):
+        """An RFC 6652 modifier with an empty value is warned about and
+        ignored; unlike redirect= and exp= it is not a permanent error,
+        because no specification makes one of it."""
+        result = checkdmarc.spf.parse_spf_record(
+            "v=spf1 ra= rp= rr= ip4:192.0.2.1 -all", "example.com"
+        )
+        self.assertIsNone(result["parsed"]["ra"])
+        self.assertIsNone(result["parsed"]["rp"])
+        self.assertIsNone(result["parsed"]["rr"])
+        self.assertEqual(
+            result["warnings"],
+            [
+                "The ra modifier is missing a value; it was ignored (RFC 6652 § 3).",
+                "The rp modifier is missing a value; it was ignored (RFC 6652 § 3).",
+                "The rr modifier is missing a value; it was ignored (RFC 6652 § 3).",
+            ],
+        )
+        self.assertNotIn("error", result)
+
+    def testRFC6652RepeatedModifierKeepsTheFirstValue(self):
+        """RFC 6652 says nothing about a repeated reporting modifier, and
+        RFC 7208 § 6 makes only redirect and exp a permerror when repeated,
+        so the first value is kept, the rest are ignored, and a warning
+        says so."""
+        result = checkdmarc.spf.parse_spf_record("v=spf1 ra=a ra=b -all", "example.com")
+        self.assertEqual(result["parsed"]["ra"], "a")
+        self.assertIn(
+            "The ra modifier appeared more than once; only the first value is kept.",
+            result["warnings"],
+        )
+        self.assertNotIn("error", result)
+
+    def testRFC6652RepeatedModifierAcrossAllKeepsTheFirstValue(self):
+        """The first value in the record wins even when the repeat is on the
+        other side of the all mechanism: the modifiers written after all are
+        recorded after the ones before it."""
+        result = checkdmarc.spf.parse_spf_record(
+            "v=spf1 ra=first -all ra=second", "example.com"
+        )
+        self.assertEqual(result["parsed"]["ra"], "first")
+        self.assertIn(
+            "The ra modifier appeared more than once; only the first value is kept.",
+            result["warnings"],
+        )
+
+    def testRFC6652ModifiersAndExpAfterAllInAnyOrder(self):
+        """An exp modifier and an RFC 6652 reporting modifier after the all
+        mechanism are both honored, whichever one comes first."""
+        for record in (
+            "v=spf1 -all exp=exp.example ra=postmaster",
+            "v=spf1 -all ra=postmaster exp=exp.example",
+        ):
+            with self.subTest(record=record):
+                with patch(
+                    "checkdmarc.spf.get_txt_records", return_value=["explanation"]
+                ):
+                    result = checkdmarc.spf.parse_spf_record(record, "example.com")
+                self.assertEqual(result["parsed"]["exp"], "exp.example")
+                self.assertEqual(result["parsed"]["ra"], "postmaster")
+                self.assertEqual(
+                    result["warnings"],
+                    [],
+                    f"nothing should be reported as ignored: {result['warnings']}",
+                )
 
     def testQualifierOnModifierIsSyntaxError(self):
         """A qualifier on a modifier does not match the RFC 7208 section 12

--- a/tests/test_spf.py
+++ b/tests/test_spf.py
@@ -1274,8 +1274,7 @@ class TestRFC7208Conformance(unittest.TestCase):
                         modifier in w and "RFC 6652" in w and "RFC 7208" in w
                         for w in warnings
                     ),
-                    f"expected a deprecation warning for {modifier}=, got "
-                    f"{warnings}",
+                    f"expected a deprecation warning for {modifier}=, got {warnings}",
                 )
                 self.assertFalse(
                     any(f"unknown modifier {modifier}" in w for w in warnings)

--- a/tests/test_spf.py
+++ b/tests/test_spf.py
@@ -1259,25 +1259,163 @@ class TestRFC7208Conformance(unittest.TestCase):
         mechanisms = [m["mechanism"] for m in result["parsed"]["mechanisms"]]
         self.assertIn("ip4", mechanisms)
 
-    def testRFC6652ModifiersDeprecatedWarning(self):
-        """ra=, rp=, rr= were valid under RFC 6652 but removed in RFC 7208;
-        they are ignored with a deprecation warning rather than the generic
-        unknown-modifier warning."""
+    def testRFC6652ModifiersValid(self):
+        """ra=, rp=, rr= are RFC 6652 § 3 reporting modifiers that RFC 7208 § 6
+        keeps working. A valid record is parsed, surfaced in the result next to
+        exp/redirect, and produces no warning."""
+        # RFC 6652 Appendix B.3 places the reporting modifiers after -all
+        result = checkdmarc.spf.parse_spf_record(
+            "v=spf1 ip4:192.0.2.1 -all ra=postmaster rp=10 rr=e", "example.com"
+        )
+        self.assertEqual(result["parsed"]["ra"], "postmaster")
+        self.assertEqual(result["parsed"]["rp"], "10")
+        self.assertEqual(result["parsed"]["rr"], ["e"])
+        self.assertEqual(result["dns_lookups"], 0)
+        self.assertEqual(result["parsed"]["all"], "fail")
+        self.assertEqual(
+            result["warnings"],
+            [],
+            f"a valid RFC 6652 record should not warn: {result['warnings']}",
+        )
+
+    def testRFC6652ModifiersBeforeAll(self):
+        """RFC 6652 modifiers may appear before the all mechanism too -
+        even if it is discouraged by the spec, it is not an error."""
+        result = checkdmarc.spf.parse_spf_record(
+            "v=spf1 ra=postmaster -all", "example.com"
+        )
+        self.assertEqual(result["parsed"]["ra"], "postmaster")
+        self.assertEqual(result["warnings"], [])
+
+    def testRFC6652RaIsLocalPart(self):
+        """ra= must be a local-part (RFC 5322 § 3.4.1); the verifier appends
+        '@' + the SPF domain, so a value that is already an address is
+        malformed."""
+        result = checkdmarc.spf.parse_spf_record(
+            "v=spf1 ra=postmaster@example.com -all", "example.com"
+        )
+        self.assertIsNone(result["parsed"]["ra"])
+        self.assertTrue(any("not a valid local-part" in w for w in result["warnings"]))
+        # A malformed ra= does not become a permerror.
+        self.assertNotIn("error", result)
+
+    def testRFC6652RpIntegerRange(self):
+        """rp= is an integer 0-100 per the erratum 6579 corrected ABNF; any
+        other value is warned about and ignored, not a syntax error."""
+        # Boundary values that are valid.
+        for value in ("0", "100", "50"):
+            with self.subTest(value=value):
+                result = checkdmarc.spf.parse_spf_record(
+                    f"v=spf1 ra=postmaster rp={value} -all", "example.com"
+                )
+                self.assertEqual(result["parsed"]["rp"], value)
+                self.assertEqual(result["warnings"], [])
+        # Out-of-range / malformed values are ignored with a warning.
+        for value in ("101", "-1", "abc", "1000"):
+            with self.subTest(value=value):
+                result = checkdmarc.spf.parse_spf_record(
+                    f"v=spf1 ra=postmaster rp={value} -all", "example.com"
+                )
+                self.assertIsNone(result["parsed"]["rp"])
+                self.assertTrue(
+                    any(
+                        "rp modifier value" in w and "ignored" in w
+                        for w in result["warnings"]
+                    ),
+                    f"expected an ignored warning for rp={value}, got {result['warnings']}",
+                )
+                self.assertNotIn("error", result)
+
+    def testRFC6652RrTokenList(self):
+        """rr= is a colon-separated list of all/e/f/s/n tokens."""
+        result = checkdmarc.spf.parse_spf_record(
+            "v=spf1 ra=postmaster rr=e:f -all", "example.com"
+        )
+        self.assertEqual(result["parsed"]["rr"], ["e", "f"])
+        self.assertEqual(result["warnings"], [])
+        # The bare default token is valid on its own.
+        result = checkdmarc.spf.parse_spf_record(
+            "v=spf1 ra=postmaster rr=all -all", "example.com"
+        )
+        self.assertEqual(result["parsed"]["rr"], ["all"])
+        self.assertEqual(result["warnings"], [])
+        # An unknown token is warned about and ignored, not a permerror.
+        result = checkdmarc.spf.parse_spf_record(
+            "v=spf1 ra=postmaster rr=e:x -all", "example.com"
+        )
+        self.assertIsNone(result["parsed"]["rr"])
+        self.assertTrue(any("rr modifier value" in w for w in result["warnings"]))
+        self.assertNotIn("error", result)
+
+    def testRFC6652RpAndRrDoNothingWithoutRa(self):
+        """RFC 6652 § 3: in the absence of an ra= tag, rp= and rr= MUST be
+        ignored, and the report generator MUST NOT issue a report."""
+        result = checkdmarc.spf.parse_spf_record(
+            "v=spf1 rp=10 rr=e ip4:192.0.2.1 -all", "example.com"
+        )
+        # The values are still surfaced (they exist in the record)...
+        self.assertEqual(result["parsed"]["rp"], "10")
+        self.assertEqual(result["parsed"]["rr"], ["e"])
+        self.assertIsNone(result["parsed"]["ra"])
+        # ...but a warning explains they have no effect.
+        self.assertTrue(
+            any("without an ra modifier" in w for w in result["warnings"]),
+            f"expected a no-effect-without-ra warning, got {result['warnings']}",
+        )
+
+    def testRFC6652RaIgnoredInInclude(self):
+        """RFC 6652 § 3: an ra= modifier in a record reached by an include
+        mechanism MUST be ignored."""
+        # The include target carries ra=postmaster; include is mocked so no
+        # network access is needed.
+        include_record = "v=spf1 ra=postmaster ip4:192.0.2.1 -all"
+        with patch("checkdmarc.spf.query_spf_record") as mock_query:
+            mock_query.return_value = {"record": include_record, "warnings": []}
+            result = checkdmarc.spf.parse_spf_record(
+                "v=spf1 include:other.example -all", "example.com"
+            )
+        included = result["parsed"]["mechanisms"][0]
+        self.assertEqual(included["mechanism"], "include")
+        self.assertEqual(included["parsed"]["ra"], "postmaster")
+        self.assertTrue(
+            any(
+                "ra modifier was ignored" in w and "include mechanism" in w
+                for w in result["warnings"]
+            ),
+            f"expected an include-ignore warning for ra=, got {result['warnings']}",
+        )
+        # The ra= value is surfaced for visibility even though it is ignored
+        # by report generators.
+        self.assertEqual(included["parsed"]["ra"], "postmaster")
+
+    def testRFC6652RaNotIgnoredInRedirect(self):
+        """A redirect target (not reached via include) keeps its ra= honored:
+        no include-ignore warning is emitted."""
+        redirect_record = "v=spf1 ra=postmaster ip4:192.0.2.1 -all"
+        with patch("checkdmarc.spf.query_spf_record") as mock_query:
+            mock_query.return_value = {"record": redirect_record, "warnings": []}
+            result = checkdmarc.spf.parse_spf_record(
+                "v=spf1 ip4:198.51.100.1 redirect=other.example", "example.com"
+            )
+        self.assertFalse(
+            any("include mechanism" in w for w in result["warnings"]),
+            f"redirect should not trigger the include-ignore warning, got {result['warnings']}",
+        )
+        self.assertFalse(any("without an ra modifier" in w for w in result["warnings"]))
+
+    def testRFC6652ModifiersAsKnownNotUnknown(self):
+        """ra=, rp=, rr= are known modifiers, so they must not get the generic
+        'unknown modifier' warning."""
         for modifier in ("ra", "rp", "rr"):
             with self.subTest(modifier=modifier):
                 result = checkdmarc.spf.parse_spf_record(
                     f"v=spf1 {modifier}=x ip4:192.0.2.1 -all", "example.com"
                 )
-                warnings = result["warnings"]
-                self.assertTrue(
-                    any(
-                        modifier in w and "RFC 6652" in w and "RFC 7208" in w
-                        for w in warnings
-                    ),
-                    f"expected a deprecation warning for {modifier}=, got {warnings}",
+                self.assertFalse(
+                    any(f"unknown modifier {modifier}" in w for w in result["warnings"])
                 )
                 self.assertFalse(
-                    any(f"unknown modifier {modifier}" in w for w in warnings)
+                    any("removed in RFC 7208" in w for w in result["warnings"])
                 )
                 self.assertEqual(result["dns_lookups"], 0)
                 self.assertEqual(result["parsed"]["all"], "fail")


### PR DESCRIPTION
This adds a more verbose warning description specifically for ra=,rp= or rr= modifiers that were previously dropped as generic warnings (as per new spec), but still sometimes appear in spf records.