### PR TITLE
Release 6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 6.0.1
 
 ### Fixed
 

--- a/checkdmarc/_constants.py
+++ b/checkdmarc/_constants.py
@@ -19,7 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-__version__ = "6.0.0"
+__version__ = "6.0.1"
 
 OS = platform.system()
 OS_RELEASE = platform.release()


### PR DESCRIPTION
Release PR for **6.0.1**, a patch release with one fix.

## Fixed

- SPF: the RFC 6652 reporting modifiers `ra=`, `rp=`, and `rr=`, added in 5.8.0 and removed later, are recognized again. Their values are validated against RFC 6652 § 3 (`rp=` per erratum 6579) and surfaced in the parsed result as `ra`, `rp`, and `rr` next to `exp`; a malformed value is warned about and ignored instead of failing the record. Warnings cover the two RFC 6652 § 3 semantic rules (`rp=` and `rr=` do nothing without `ra=`; `ra=` is ignored in a record reached through an `include`), and `exp=` and these modifiers are now honored after `all` in any order. (#274, thanks @AdsanTheGreat)

## Release-time changes in this PR

- `checkdmarc/_constants.py`: `__version__` 6.0.0 → 6.0.1
- `CHANGELOG.md`: `## Unreleased` → `## 6.0.1`

After merging, the release is triggered by pushing the annotated `6.0.1` tag on the merge commit; `release.yml` runs CI, publishes to PyPI, creates the GitHub Release from this changelog section, and deploys the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
